### PR TITLE
feat(blog): add series support

### DIFF
--- a/app/components/index.tsx
+++ b/app/components/index.tsx
@@ -9,3 +9,5 @@ export { PageTitle } from "./page-title"
 export { Card } from "./card"
 
 export { ExternalLink } from "./external-link"
+
+export { MermaidDiagram } from "./mermaid-diagram"

--- a/app/components/mermaid-diagram.tsx
+++ b/app/components/mermaid-diagram.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useId, useMemo, useState } from "react"
+
+type MermaidDiagramProps = {
+  title: string
+  caption?: string
+  chart: string
+}
+
+export function MermaidDiagram({ title, caption, chart }: MermaidDiagramProps) {
+  const reactId = useId()
+  const diagramId = useMemo(
+    () => `mermaid-${reactId.replace(/[^a-zA-Z0-9_-]/g, "")}`,
+    [reactId],
+  )
+  const [svg, setSvg] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function renderDiagram() {
+      try {
+        const mermaid = (await import("mermaid")).default
+
+        mermaid.initialize({
+          startOnLoad: false,
+          securityLevel: "strict",
+          theme: "neutral",
+        })
+
+        const result = await mermaid.render(diagramId, chart)
+
+        if (!cancelled) {
+          setSvg(result.svg)
+          setError(null)
+        }
+      } catch (caught) {
+        if (!cancelled) {
+          setSvg(null)
+          setError(caught instanceof Error ? caught.message : "Unable to render diagram")
+        }
+      }
+    }
+
+    renderDiagram()
+
+    return () => {
+      cancelled = true
+    }
+  }, [chart, diagramId])
+
+  return (
+    <figure className="article-diagram">
+      <figcaption className="article-diagram-caption">
+        <span className="article-diagram-title">{title}</span>
+        {caption ? <span className="article-diagram-note">{caption}</span> : null}
+      </figcaption>
+
+      {svg ? (
+        <div
+          className="overflow-x-auto rounded-2xl bg-white p-4"
+          dangerouslySetInnerHTML={{ __html: svg }}
+        />
+      ) : error ? (
+        <pre className="overflow-x-auto rounded-2xl bg-slate-950 p-4 text-sm leading-7 text-slate-100">
+          {chart}
+        </pre>
+      ) : (
+        <pre className="overflow-x-auto rounded-2xl bg-slate-100 p-4 text-sm leading-7 text-slate-700">
+          {chart}
+        </pre>
+      )}
+    </figure>
+  )
+}

--- a/app/components/mermaid-diagram.tsx
+++ b/app/components/mermaid-diagram.tsx
@@ -1,75 +1,25 @@
-import { useEffect, useId, useMemo, useState } from "react"
-
 type MermaidDiagramProps = {
-  title: string
-  caption?: string
-  chart: string
-}
+  title: string;
+  caption?: string;
+  chart: string;
+};
 
 export function MermaidDiagram({ title, caption, chart }: MermaidDiagramProps) {
-  const reactId = useId()
-  const diagramId = useMemo(
-    () => `mermaid-${reactId.replace(/[^a-zA-Z0-9_-]/g, "")}`,
-    [reactId],
-  )
-  const [svg, setSvg] = useState<string | null>(null)
-  const [error, setError] = useState<string | null>(null)
-
-  useEffect(() => {
-    let cancelled = false
-
-    async function renderDiagram() {
-      try {
-        const mermaid = (await import("mermaid")).default
-
-        mermaid.initialize({
-          startOnLoad: false,
-          securityLevel: "strict",
-          theme: "neutral",
-        })
-
-        const result = await mermaid.render(diagramId, chart)
-
-        if (!cancelled) {
-          setSvg(result.svg)
-          setError(null)
-        }
-      } catch (caught) {
-        if (!cancelled) {
-          setSvg(null)
-          setError(caught instanceof Error ? caught.message : "Unable to render diagram")
-        }
-      }
-    }
-
-    renderDiagram()
-
-    return () => {
-      cancelled = true
-    }
-  }, [chart, diagramId])
-
   return (
-    <figure className="article-diagram">
+    <figure className="article-diagram mb-10" data-mermaid-diagram>
       <figcaption className="article-diagram-caption">
         <span className="article-diagram-title">{title}</span>
-        {caption ? <span className="article-diagram-note">{caption}</span> : null}
+        {caption ? (
+          <span className="article-diagram-note">{caption}</span>
+        ) : null}
       </figcaption>
 
-      {svg ? (
-        <div
-          className="overflow-x-auto rounded-2xl bg-white p-4"
-          dangerouslySetInnerHTML={{ __html: svg }}
-        />
-      ) : error ? (
-        <pre className="overflow-x-auto rounded-2xl bg-slate-950 p-4 text-sm leading-7 text-slate-100">
-          {chart}
-        </pre>
-      ) : (
-        <pre className="overflow-x-auto rounded-2xl bg-slate-100 p-4 text-sm leading-7 text-slate-700">
-          {chart}
-        </pre>
-      )}
+      <pre
+        className="overflow-x-auto rounded-2xl p-4 text-sm leading-7 text-slate-700"
+        data-mermaid-source
+      >
+        {chart}
+      </pre>
     </figure>
-  )
+  );
 }

--- a/app/content/blog-governance-native.tsx
+++ b/app/content/blog-governance-native.tsx
@@ -1,3 +1,4 @@
+import { MermaidDiagram } from "~/components"
 import type { BlogPost } from "~/content/blog"
 
 const governanceNativeEngineeringContent = () => (
@@ -19,6 +20,18 @@ const governanceNativeEngineeringContent = () => (
         </p>
       </div>
     </section>
+
+    <MermaidDiagram
+      title="AI-native engineering control plane"
+      caption="Generation increases throughput; governance preserves intent, evidence, and reviewability."
+      chart={`flowchart LR
+  A[Human intent] --> B[Policy and review boundaries]
+  B --> C[Agent or model execution]
+  C --> D[Generated change]
+  D --> E[Evidence and replay envelope]
+  E --> F[Human comprehension loop]
+  F --> B`}
+    />
 
     <section className="space-y-4">
       <h2>The bottleneck has moved</h2>
@@ -98,6 +111,20 @@ const replayabilityGovernanceContent = () => (
       </div>
     </section>
 
+    <MermaidDiagram
+      title="Replayability as evidence lifecycle"
+      caption="Replay confidence depends on captured evidence and decays as provider and runtime facts expire."
+      chart={`flowchart TD
+  A[Execution request] --> B[Provider routing decision]
+  B --> C[Model response]
+  C --> D[Replay envelope]
+  D --> E[Audit or review]
+  D --> F[Evidence decay]
+  F --> G{Replay claim still valid?}
+  G -->|yes| E
+  G -->|no| H[Downgrade replayability claim]`}
+    />
+
     <section className="space-y-4">
       <h2>Replayability vs reproducibility</h2>
       <p>
@@ -170,6 +197,21 @@ const recursiveGovernanceContent = () => (
         not only orchestration. It is governed recursion.
       </p>
     </section>
+
+    <MermaidDiagram
+      title="Governed recursive execution"
+      caption="Recursive fan-out must preserve authority boundaries, lineage, and replay ceilings."
+      chart={`flowchart TD
+  A[Workflow request] --> B[Planner]
+  B --> C[Bounded task A]
+  B --> D[Bounded task B]
+  B --> E[Reviewer]
+  C --> F[Evidence]
+  D --> F
+  E --> F
+  F --> G[Governed synthesis]
+  G --> H[Human review boundary]`}
+    />
 
     <section className="space-y-4">
       <h2>The core tension</h2>

--- a/app/content/blog-governance-native.tsx
+++ b/app/content/blog-governance-native.tsx
@@ -1,0 +1,283 @@
+import type { BlogPost } from "~/content/blog"
+
+const governanceNativeEngineeringContent = () => (
+  <>
+    <section className="space-y-4">
+      <h2>Generated code changes the control plane</h2>
+      <p>
+        AI-native engineering creates a control-plane problem. Generated code can
+        increase implementation throughput, but without intent capture,
+        execution evidence, review boundaries, replayability guarantees, and
+        human comprehension loops, organizations accumulate technical,
+        cognitive, and intent debt faster than they can repay it.
+      </p>
+      <div className="article-callout">
+        <p>
+          The bottleneck is shifting from whether agents can produce code to
+          whether organizations can still govern, review, explain, and safely
+          change the systems agents help create.
+        </p>
+      </div>
+    </section>
+
+    <section className="space-y-4">
+      <h2>The bottleneck has moved</h2>
+      <p>
+        The bottleneck is no longer purely implementation throughput. It is now
+        increasingly governance, replayability, operational trust,
+        organizational memory, reviewability, and comprehension preservation.
+      </p>
+      <p>
+        Transport-compatible APIs and interchangeable model providers create
+        operational flexibility. They do not create governance equivalence. A
+        local model, an enterprise-hosted provider, a distributed inference
+        fabric, and a public shared service can expose similar APIs while
+        carrying very different trust, retention, locality, and replayability
+        properties.
+      </p>
+    </section>
+
+    <section className="space-y-4">
+      <h2>The governance surface</h2>
+      <p>
+        Inference-provider selection is not merely infrastructure configuration.
+        It is a governance decision involving locality, retention,
+        replayability, evidence quality, trust boundaries, and policy
+        constraints.
+      </p>
+      <p>
+        The same applies to prompts, tool access, execution plans, review gates,
+        workflow composition, and write-back operations. These are not incidental
+        implementation details. They are control surfaces.
+      </p>
+    </section>
+
+    <section className="space-y-4">
+      <h2>Anthesis direction</h2>
+      <p>
+        Anthesis treats prompts, execution, provider routing, replay evidence,
+        workflow composition, approvals, and policy evaluation as explicit
+        governance surfaces. The point is not to eliminate agents. The point is
+        to ensure humans remain capable of review, replay, intervention,
+        attribution, and governance while agents accelerate execution.
+      </p>
+    </section>
+
+    <section className="space-y-4">
+      <h2>Draft thesis</h2>
+      <p>
+        The next generation of engineering systems may differentiate less on raw
+        generation quality and more on governance clarity, replayability,
+        organizational comprehensibility, bounded autonomy, evidence quality,
+        and intent preservation.
+      </p>
+      <p>
+        AI-native engineering therefore becomes a systems-governance discipline,
+        not merely a prompting discipline.
+      </p>
+    </section>
+  </>
+)
+
+const replayabilityGovernanceContent = () => (
+  <>
+    <section className="space-y-4">
+      <h2>Determinism is not the whole problem</h2>
+      <p>
+        Most conversations around AI reproducibility focus on determinism. That
+        matters, but deterministic replay is only one part of the problem. The
+        larger issue is governance: whether an organization can explain what
+        happened, why it happened, under whose authority it happened, and what
+        evidence still exists to support that claim.
+      </p>
+      <div className="article-callout">
+        <p>
+          Replayability in AI-native systems is not just reproducibility
+          engineering. It is governance infrastructure.
+        </p>
+      </div>
+    </section>
+
+    <section className="space-y-4">
+      <h2>Replayability vs reproducibility</h2>
+      <p>
+        Traditional software systems often assume identical binaries, stable
+        execution environments, deterministic inputs, and recoverable runtime
+        state. AI systems violate many of those assumptions.
+      </p>
+      <p>
+        Providers change. Models mutate. Routing changes. Retention windows
+        expire. Metadata disappears. As a result, replayability becomes an
+        evidence problem, not only a runtime problem.
+      </p>
+    </section>
+
+    <section className="space-y-4">
+      <h2>Replayability ceilings</h2>
+      <p>
+        Different inference providers support different replayability ceilings.
+        A local deterministic runtime and a shared external provider may expose
+        compatible APIs while offering radically different replay guarantees.
+      </p>
+      <p>
+        Replayability must therefore be explicit, policy-aware, evidence-backed,
+        and surfaced to governance systems rather than hidden behind SDK
+        abstractions.
+      </p>
+    </section>
+
+    <section className="space-y-4">
+      <h2>Replayability decay</h2>
+      <p>
+        Replayability is not static. It decays over time as models are replaced,
+        provider attestations expire, evidence is garbage-collected, execution
+        metadata disappears, and retention windows close.
+      </p>
+      <p>
+        Governance systems should model that decay explicitly. A system should
+        not silently preserve a stronger replayability claim after the evidence
+        required to support it has expired.
+      </p>
+    </section>
+
+    <section className="space-y-4">
+      <h2>Anthesis perspective</h2>
+      <p>
+        Anthesis treats replayability as a first-class governance surface.
+        Replay evidence is attached to workflow execution, provider routing,
+        execution lineage, policy evaluation, and governance signals.
+      </p>
+      <p>
+        The goal is not perfect determinism. The goal is bounded explainability
+        and attributable execution.
+      </p>
+    </section>
+  </>
+)
+
+const recursiveGovernanceContent = () => (
+  <>
+    <section className="space-y-4">
+      <h2>Recursive agents need governed recursion</h2>
+      <p>
+        Recursive agent systems are becoming increasingly attractive.
+        Hierarchical planners, reviewer trees, recursive decomposition systems,
+        and latent collaboration models promise better reasoning scalability
+        than flat prompting alone.
+      </p>
+      <p>
+        But recursive systems introduce governance problems. The challenge is
+        not only orchestration. It is governed recursion.
+      </p>
+    </section>
+
+    <section className="space-y-4">
+      <h2>The core tension</h2>
+      <p>
+        Recursive systems can expand execution depth, execution fan-out,
+        authority propagation, context contamination, replay ambiguity, and
+        provenance collapse faster than traditional orchestration systems were
+        designed to handle.
+      </p>
+      <div className="article-callout">
+        <p>
+          A workflow cannot claim stronger governance properties than the weakest
+          materially contributing execution boundary.
+        </p>
+      </div>
+    </section>
+
+    <section className="space-y-4">
+      <h2>Observable vs latent execution</h2>
+      <p>
+        Not all recursive execution is equally observable. Some systems expose
+        explicit execution nodes, review boundaries, execution lineage, and
+        structured delegation. Others operate partly in latent space or opaque
+        runtime layers.
+      </p>
+      <p>
+        Governance systems must distinguish observable execution, opaque
+        execution, latent execution, and synthesized outputs without pretending
+        complete introspection exists.
+      </p>
+    </section>
+
+    <section className="space-y-4">
+      <h2>Replayability boundaries</h2>
+      <p>
+        Recursive systems complicate replayability. Advisory branches may remain
+        excluded from a replay envelope, but synthesis-influencing branches
+        become governance-relevant. Latent recursive execution constrains replay
+        ceilings because it contributes to the delivered output without exposing
+        the same evidence surface as explicit execution.
+      </p>
+      <p>
+        Replayability therefore propagates across execution lineage.
+      </p>
+    </section>
+
+    <section className="space-y-4">
+      <h2>Anthesis direction</h2>
+      <p>
+        Anthesis treats recursive coordination as profiles over governed
+        execution graphs, bounded execution expansion, evidence-linked workflow
+        composition, and policy-governed delegation rather than unrestricted
+        autonomous recursion.
+      </p>
+      <p>
+        The long-term challenge is not simply building more capable recursive
+        agents. It is ensuring humans remain capable of comprehension,
+        intervention, replay, audit, and authority governance after recursive
+        systems become operationally useful.
+      </p>
+    </section>
+  </>
+)
+
+export const governanceNativeBlogPosts: BlogPost[] = [
+  {
+    slug: "governance-native-engineering-control-plane",
+    title: "Governance-Native Engineering and the AI Control Plane",
+    description:
+      "AI-native engineering shifts the bottleneck from implementation throughput toward governance, replayability, and organizational comprehension.",
+    date: "2026-05-18",
+    excerpt:
+      "Generated code increases throughput, but without intent capture, evidence, review boundaries, replayability guarantees, and human comprehension loops, organizations accumulate governance debt.",
+    tags: ["ai-governance", "anthesis", "delivery-governance", "architecture-notes"],
+    relatedSlugs: [
+      "replayability-is-a-governance-problem",
+      "recursive-governance-and-agent-workflows",
+    ],
+    Content: governanceNativeEngineeringContent,
+  },
+  {
+    slug: "replayability-is-a-governance-problem",
+    title: "Replayability Is a Governance Problem",
+    description:
+      "Replayability in AI-native systems is not just reproducibility engineering. It is governance infrastructure.",
+    date: "2026-05-18",
+    excerpt:
+      "Replayability becomes an evidence problem when providers change, models mutate, routing shifts, retention windows expire, and metadata disappears.",
+    tags: ["ai-governance", "replayability", "anthesis", "architecture-notes"],
+    relatedSlugs: [
+      "governance-native-engineering-control-plane",
+      "recursive-governance-and-agent-workflows",
+    ],
+    Content: replayabilityGovernanceContent,
+  },
+  {
+    slug: "recursive-governance-and-agent-workflows",
+    title: "Recursive Governance and Agent Workflows",
+    description:
+      "Recursive and hierarchical agent systems require governance boundaries, replay semantics, and observable execution surfaces.",
+    date: "2026-05-18",
+    excerpt:
+      "Recursive systems can expand execution depth, authority propagation, context contamination, replay ambiguity, and provenance collapse faster than traditional orchestration can govern.",
+    tags: ["ai-governance", "recursive-systems", "anthesis", "architecture-notes"],
+    relatedSlugs: [
+      "governance-native-engineering-control-plane",
+      "replayability-is-a-governance-problem",
+    ],
+    Content: recursiveGovernanceContent,
+  },
+]

--- a/app/content/blog-governance-native.tsx
+++ b/app/content/blog-governance-native.tsx
@@ -24,7 +24,7 @@ const governanceNativeEngineeringContent = () => (
     <MermaidDiagram
       title="AI-native engineering control plane"
       caption="Generation increases throughput; governance preserves intent, evidence, and reviewability."
-      chart={`flowchart LR
+      chart={`flowchart TD
   A[Human intent] --> B[Policy and review boundaries]
   B --> C[Agent or model execution]
   C --> D[Generated change]

--- a/app/content/blog-provider.ts
+++ b/app/content/blog-provider.ts
@@ -1,0 +1,39 @@
+import type { BlogPost } from "~/content/blog"
+import { blogPosts } from "~/content/blog"
+import { governanceNativeBlogPosts } from "~/content/blog-governance-native"
+
+export interface BlogContentProvider {
+  getPosts(): BlogPost[]
+  getPostBySlug(slug: string): BlogPost | null
+}
+
+const tsxBlogPosts: BlogPost[] = [
+  ...governanceNativeBlogPosts,
+  ...blogPosts,
+]
+
+export const tsxBlogProvider: BlogContentProvider = {
+  getPosts() {
+    return tsxBlogPosts
+  },
+
+  getPostBySlug(slug: string) {
+    return tsxBlogPosts.find((post) => post.slug === slug) ?? null
+  },
+}
+
+export const blogContentProvider = tsxBlogProvider
+
+export function getBlogPosts() {
+  return blogContentProvider.getPosts()
+}
+
+export function getBlogPostBySlug(slug: string) {
+  return blogContentProvider.getPostBySlug(slug)
+}
+
+export function getRelatedPosts(post: BlogPost) {
+  return post.relatedSlugs
+    .map((slug) => getBlogPostBySlug(slug))
+    .filter((candidate): candidate is BlogPost => candidate !== null)
+}

--- a/app/content/blog-series.ts
+++ b/app/content/blog-series.ts
@@ -1,5 +1,5 @@
 import type { BlogPost } from "~/content/blog"
-import { getBlogPosts, getBlogPostBySlug } from "~/content/blog"
+import { getBlogPosts, getBlogPostBySlug } from "~/content/blog-provider"
 
 export type BlogSeriesDefinition = {
   slug: string
@@ -54,10 +54,16 @@ export function getBlogSeriesBySlug(slug: string) {
   return getBlogSeriesGroups().find((series) => series.slug === slug) ?? null
 }
 
-export function getSeriesNavigation(post: BlogPost) {
-  const series = getBlogSeriesGroups().find((candidate) =>
-    candidate.posts.some((seriesPost) => seriesPost.slug === post.slug),
+export function getSeriesForPost(post: BlogPost) {
+  return (
+    getBlogSeriesGroups().find((series) =>
+      series.posts.some((seriesPost) => seriesPost.slug === post.slug),
+    ) ?? null
   )
+}
+
+export function getSeriesNavigation(post: BlogPost) {
+  const series = getSeriesForPost(post)
 
   if (!series) {
     return null

--- a/app/content/blog-series.ts
+++ b/app/content/blog-series.ts
@@ -1,0 +1,81 @@
+import type { BlogPost } from "~/content/blog"
+import { getBlogPosts, getBlogPostBySlug } from "~/content/blog"
+
+export type BlogSeriesDefinition = {
+  slug: string
+  title: string
+  description: string
+  postSlugs: string[]
+}
+
+export type BlogSeriesGroup = BlogSeriesDefinition & {
+  posts: BlogPost[]
+}
+
+const blogSeriesDefinitions: BlogSeriesDefinition[] = [
+  {
+    slug: "architecture-control-boundaries",
+    title: "Architecture Control Boundaries",
+    description:
+      "Architecture notes on integration, AI workflow boundaries, and layered software design as delivery-governance surfaces.",
+    postSlugs: [
+      "secure-platform-integration-is-not-plumbing",
+      "ai-pipelines-need-control-boundaries",
+      "software-layers-are-risk-boundaries",
+    ],
+  },
+]
+
+function resolveSeriesPosts(series: BlogSeriesDefinition) {
+  return series.postSlugs
+    .map((slug) => getBlogPostBySlug(slug))
+    .filter((post): post is BlogPost => post !== null)
+}
+
+export function getBlogSeriesGroups(): BlogSeriesGroup[] {
+  return blogSeriesDefinitions.map((series) => ({
+    ...series,
+    posts: resolveSeriesPosts(series),
+  }))
+}
+
+export function getBlogSeriesBySlug(slug: string) {
+  return getBlogSeriesGroups().find((series) => series.slug === slug) ?? null
+}
+
+export function getSeriesNavigation(post: BlogPost) {
+  const series = getBlogSeriesGroups().find((candidate) =>
+    candidate.posts.some((seriesPost) => seriesPost.slug === post.slug),
+  )
+
+  if (!series) {
+    return null
+  }
+
+  const index = series.posts.findIndex((seriesPost) => seriesPost.slug === post.slug)
+
+  if (index === -1) {
+    return null
+  }
+
+  return {
+    series: {
+      slug: series.slug,
+      title: series.title,
+      order: index + 1,
+    },
+    index,
+    total: series.posts.length,
+    previous: series.posts[index - 1] ?? null,
+    next: series.posts[index + 1] ?? null,
+    posts: series.posts,
+  }
+}
+
+export function getNonSeriesBlogPosts() {
+  const seriesSlugs = new Set(
+    blogSeriesDefinitions.flatMap((series) => series.postSlugs),
+  )
+
+  return getBlogPosts().filter((post) => !seriesSlugs.has(post.slug))
+}

--- a/app/content/blog-series.ts
+++ b/app/content/blog-series.ts
@@ -14,6 +14,17 @@ export type BlogSeriesGroup = BlogSeriesDefinition & {
 
 const blogSeriesDefinitions: BlogSeriesDefinition[] = [
   {
+    slug: "governance-native-engineering",
+    title: "Governance-Native Engineering",
+    description:
+      "Essays exploring governance, replayability, recursive execution, and organizational comprehension in AI-native engineering systems.",
+    postSlugs: [
+      "governance-native-engineering-control-plane",
+      "replayability-is-a-governance-problem",
+      "recursive-governance-and-agent-workflows",
+    ],
+  },
+  {
     slug: "architecture-control-boundaries",
     title: "Architecture Control Boundaries",
     description:

--- a/app/content/blog.tsx
+++ b/app/content/blog.tsx
@@ -1,6 +1,12 @@
 import type { ReactNode } from "react"
 import { Link } from "@remix-run/react"
 
+export type BlogSeries = {
+  slug: string
+  title: string
+  order: number
+}
+
 export type BlogPost = {
   slug: string
   title: string
@@ -9,7 +15,14 @@ export type BlogPost = {
   excerpt: string
   tags: string[]
   relatedSlugs: string[]
+  series?: BlogSeries
   Content: () => ReactNode
+}
+
+export type BlogSeriesGroup = {
+  slug: string
+  title: string
+  posts: BlogPost[]
 }
 
 export const BLOG_TITLE = "Architecture Notes"
@@ -588,6 +601,58 @@ export function getRelatedPosts(post: BlogPost) {
   return post.relatedSlugs
     .map((slug) => getBlogPostBySlug(slug))
     .filter((candidate): candidate is BlogPost => candidate !== null)
+}
+
+export function getBlogSeriesGroups() {
+  const groups = new Map<string, BlogSeriesGroup>()
+
+  for (const post of blogPosts) {
+    if (!post.series) continue
+
+    const existingGroup = groups.get(post.series.slug)
+    const group = existingGroup ?? {
+      slug: post.series.slug,
+      title: post.series.title,
+      posts: [],
+    }
+
+    group.posts.push(post)
+    groups.set(post.series.slug, group)
+  }
+
+  return Array.from(groups.values()).map((group) => ({
+    ...group,
+    posts: [...group.posts].sort(
+      (left, right) => (left.series?.order ?? 0) - (right.series?.order ?? 0),
+    ),
+  }))
+}
+
+export function getBlogSeriesBySlug(slug: string) {
+  return getBlogSeriesGroups().find((series) => series.slug === slug) ?? null
+}
+
+export function getSeriesPosts(post: BlogPost) {
+  if (!post.series) return []
+  return getBlogSeriesBySlug(post.series.slug)?.posts ?? []
+}
+
+export function getSeriesNavigation(post: BlogPost) {
+  const seriesPosts = getSeriesPosts(post)
+  const index = seriesPosts.findIndex((candidate) => candidate.slug === post.slug)
+
+  if (index === -1 || !post.series) {
+    return null
+  }
+
+  return {
+    series: post.series,
+    index,
+    total: seriesPosts.length,
+    previous: seriesPosts[index - 1] ?? null,
+    next: seriesPosts[index + 1] ?? null,
+    posts: seriesPosts,
+  }
 }
 
 export function formatBlogDate(date: string) {

--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -1,9 +1,54 @@
-import { RemixBrowser } from "@remix-run/react"
-import { hydrateRoot } from "react-dom/client"
+import { RemixBrowser } from "@remix-run/react";
+import { hydrateRoot } from "react-dom/client";
 
 // Temporary production hardening: disable hydration until SSR/client mismatch is fully root-caused.
-const ENABLE_HYDRATION = false
+const ENABLE_HYDRATION = false;
+
+async function renderMermaidDiagrams() {
+  const diagramFigures = Array.from(
+    document.querySelectorAll<HTMLElement>("[data-mermaid-diagram]"),
+  );
+
+  if (diagramFigures.length === 0) return;
+
+  const mermaid = (await import("mermaid")).default;
+
+  mermaid.initialize({
+    startOnLoad: false,
+    securityLevel: "strict",
+    theme: "neutral",
+    themeCSS: `
+      .nodeLabel p {
+        font-size: 16px;
+        line-height: 1.5;
+      }
+    `,
+  });
+
+  await Promise.all(
+    diagramFigures.map(async (figure, index) => {
+      const source = figure.querySelector<HTMLElement>("[data-mermaid-source]");
+      const chart = source?.textContent?.trim();
+
+      if (!source || !chart) return;
+
+      try {
+        const result = await mermaid.render(`mermaid-${index}`, chart);
+        const container = document.createElement("div");
+
+        container.className = "overflow-x-auto rounded-2xl p-4";
+        container.innerHTML = result.svg;
+        source.replaceWith(container);
+      } catch {
+        source.className =
+          "overflow-x-auto rounded-2xl p-4 text-sm leading-7 text-slate-100";
+      }
+    }),
+  );
+}
+
+void renderMermaidDiagrams();
 
 if (ENABLE_HYDRATION) {
-  hydrateRoot(document, <RemixBrowser />)
+  hydrateRoot(document, <RemixBrowser />);
 }

--- a/app/routes/blog.$slug.tsx
+++ b/app/routes/blog.$slug.tsx
@@ -6,8 +6,8 @@ import {
   formatBlogDate,
   getBlogPostBySlug,
   getRelatedPosts,
-  getSeriesNavigation,
 } from "~/content/blog"
+import { getSeriesNavigation } from "~/content/blog-series"
 import { buildArticleMeta, buildArticleStructuredData } from "~/utils/seo"
 
 type LoaderData = {
@@ -146,7 +146,7 @@ export default function BlogPostRoute() {
             In this series
           </h2>
           <div className="grid gap-3">
-            {seriesNavigation.posts.map((seriesPost) => {
+            {seriesNavigation.posts.map((seriesPost, index) => {
               const isCurrent = seriesPost.slug === post.slug
 
               return (
@@ -161,7 +161,7 @@ export default function BlogPostRoute() {
                   }
                 >
                   <span className="meta-kicker mb-1 block">
-                    Part {seriesPost.series?.order}
+                    Part {index + 1}
                   </span>
                   <span className="block text-[1.02rem] font-semibold leading-7 tracking-[-0.015em] text-slate-900">
                     {seriesPost.title}

--- a/app/routes/blog.$slug.tsx
+++ b/app/routes/blog.$slug.tsx
@@ -4,9 +4,11 @@ import { Link, useLoaderData } from "@remix-run/react"
 import { PageTitle } from "~/components"
 import {
   formatBlogDate,
+} from "~/content/blog"
+import {
   getBlogPostBySlug,
   getRelatedPosts,
-} from "~/content/blog"
+} from "~/content/blog-provider"
 import { getSeriesNavigation } from "~/content/blog-series"
 import { buildArticleMeta, buildArticleStructuredData } from "~/utils/seo"
 

--- a/app/routes/blog.$slug.tsx
+++ b/app/routes/blog.$slug.tsx
@@ -6,6 +6,7 @@ import {
   formatBlogDate,
   getBlogPostBySlug,
   getRelatedPosts,
+  getSeriesNavigation,
 } from "~/content/blog"
 import { buildArticleMeta, buildArticleStructuredData } from "~/utils/seo"
 
@@ -79,6 +80,7 @@ export default function BlogPostRoute() {
   }
 
   const relatedPosts = getRelatedPosts(post)
+  const seriesNavigation = getSeriesNavigation(post)
 
   return (
     <article className="space-y-10">
@@ -95,9 +97,84 @@ export default function BlogPostRoute() {
         <p className="article-lead">{post.excerpt}</p>
       </div>
 
+      {seriesNavigation ? (
+        <section className="max-w-3xl rounded-2xl border border-slate-200 bg-slate-50/80 px-5 py-5 shadow-[0_10px_24px_rgba(31,42,42,0.05)]">
+          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div className="space-y-2">
+              <p className="meta-kicker">Series</p>
+              <h2 className="text-[1.25rem] font-semibold tracking-[-0.02em] text-slate-900">
+                <Link to={`/blog/series/${seriesNavigation.series.slug}`}>
+                  {seriesNavigation.series.title}
+                </Link>
+              </h2>
+              <p className="page-copy-sm">
+                Part {seriesNavigation.index + 1} of {seriesNavigation.total}
+              </p>
+            </div>
+            <nav
+              className="grid gap-2 text-sm md:min-w-[16rem]"
+              aria-label={`${seriesNavigation.series.title} series navigation`}
+            >
+              {seriesNavigation.previous ? (
+                <Link
+                  className="article-meta-link"
+                  to={`/blog/${seriesNavigation.previous.slug}`}
+                >
+                  Previous: {seriesNavigation.previous.title}
+                </Link>
+              ) : null}
+              {seriesNavigation.next ? (
+                <Link
+                  className="article-meta-link"
+                  to={`/blog/${seriesNavigation.next.slug}`}
+                >
+                  Next: {seriesNavigation.next.title}
+                </Link>
+              ) : null}
+            </nav>
+          </div>
+        </section>
+      ) : null}
+
       <div className="article-prose">
         <post.Content />
       </div>
+
+      {seriesNavigation ? (
+        <section className="max-w-3xl space-y-4 border-t border-gray-200 pt-8">
+          <h2 className="text-[1.35rem] font-semibold tracking-[-0.02em] text-slate-900">
+            In this series
+          </h2>
+          <div className="grid gap-3">
+            {seriesNavigation.posts.map((seriesPost) => {
+              const isCurrent = seriesPost.slug === post.slug
+
+              return (
+                <Link
+                  key={seriesPost.slug}
+                  to={`/blog/${seriesPost.slug}`}
+                  aria-current={isCurrent ? "page" : undefined}
+                  className={
+                    isCurrent
+                      ? "rounded-2xl border border-slate-300 bg-white px-4 py-4 text-left text-base shadow-[0_10px_24px_rgba(31,42,42,0.08)]"
+                      : "rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-4 text-left text-base shadow-[0_10px_24px_rgba(31,42,42,0.05)] transition-colors hover:bg-white"
+                  }
+                >
+                  <span className="meta-kicker mb-1 block">
+                    Part {seriesPost.series?.order}
+                  </span>
+                  <span className="block text-[1.02rem] font-semibold leading-7 tracking-[-0.015em] text-slate-900">
+                    {seriesPost.title}
+                  </span>
+                  <span className="mt-2 block text-sm leading-7 text-slate-600">
+                    {seriesPost.excerpt}
+                  </span>
+                </Link>
+              )
+            })}
+          </div>
+        </section>
+      ) : null}
 
       {relatedPosts.length > 0 ? (
         <section className="max-w-3xl space-y-4 border-t border-gray-200 pt-8">

--- a/app/routes/blog._index.tsx
+++ b/app/routes/blog._index.tsx
@@ -5,8 +5,9 @@ import {
   BLOG_DESCRIPTION,
   BLOG_TITLE,
   formatBlogDate,
-  getBlogPosts,
 } from "~/content/blog"
+import { getBlogPosts } from "~/content/blog-provider"
+import { getSeriesNavigation } from "~/content/blog-series"
 import { cardStyles } from "~/utils/card-styles"
 import { buildCollectionPageStructuredData, buildPageMeta } from "~/utils/seo"
 
@@ -51,30 +52,50 @@ export default function BlogIndexRoute() {
       </section>
 
       <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-        {posts.map((post, index) => (
-          <Card
-            key={post.slug}
-            title={post.title}
-            url={`/blog/${post.slug}`}
-            headingLevel={2}
-            className={
-              index === 0
-                ? `${cardStyles.neutral} editorial-card`
-                : index === 1
-                  ? `${cardStyles.blue} editorial-card`
-                  : `${cardStyles.green} editorial-card`
-            }
-          >
-            <>
-              <span className="meta-kicker mb-3 block">
-                {formatBlogDate(post.date)}
-              </span>
-              <span className="block text-[1.02rem] leading-8 text-slate-700">
-                {post.excerpt}
-              </span>
-            </>
-          </Card>
-        ))}
+        {posts.map((post, index) => {
+          const seriesNavigation = getSeriesNavigation(post)
+
+          return (
+            <Card
+              key={post.slug}
+              title={post.title}
+              url={`/blog/${post.slug}`}
+              headingLevel={2}
+              className={
+                index % 3 === 0
+                  ? `${cardStyles.neutral} editorial-card`
+                  : index % 3 === 1
+                    ? `${cardStyles.blue} editorial-card`
+                    : `${cardStyles.green} editorial-card`
+              }
+            >
+              <>
+                {seriesNavigation ? (
+                  <div className="meta-kicker mb-3 flex flex-wrap items-center gap-1.5">
+                    <span
+                      className="rounded-full border border-slate-300 bg-white text-slate-600"
+                      style={{
+                        fontSize: "0.58rem",
+                        letterSpacing: "0.14em",
+                        lineHeight: 1,
+                        padding: "0.14rem 0.38rem",
+                      }}
+                    >
+                      Part {seriesNavigation.index + 1}
+                    </span>
+                    <span>{seriesNavigation.series.title}</span>
+                  </div>
+                ) : null}
+                <span className="meta-kicker mb-3 block">
+                  {formatBlogDate(post.date)}
+                </span>
+                <span className="block text-[1.02rem] leading-8 text-slate-700">
+                  {post.excerpt}
+                </span>
+              </>
+            </Card>
+          )
+        })}
       </section>
 
       <section className="editorial-panel max-w-3xl space-y-4 bg-slate-50/80 px-6 py-6">

--- a/app/routes/blog.series.$slug.tsx
+++ b/app/routes/blog.series.$slug.tsx
@@ -1,0 +1,3 @@
+export default function BlogSeriesRoute() {
+  return <div>Series Route</div>
+}

--- a/app/routes/blog.series.$slug.tsx
+++ b/app/routes/blog.series.$slug.tsx
@@ -2,7 +2,8 @@ import type { LoaderFunctionArgs, MetaFunction } from "@remix-run/node"
 import { json } from "@remix-run/node"
 import { Link, useLoaderData } from "@remix-run/react"
 import { Card, PageTitle } from "~/components"
-import { formatBlogDate, getBlogSeriesBySlug } from "~/content/blog"
+import { formatBlogDate } from "~/content/blog"
+import { getBlogSeriesBySlug } from "~/content/blog-series"
 import { cardStyles } from "~/utils/card-styles"
 import { buildPageMeta } from "~/utils/seo"
 
@@ -36,7 +37,6 @@ export async function loader({ params }: LoaderFunctionArgs) {
         title: post.title,
         excerpt: post.excerpt,
         date: post.date,
-        order: post.series?.order,
       })),
     },
   })
@@ -89,7 +89,7 @@ export default function BlogSeriesRoute() {
           >
             <>
               <span className="meta-kicker mb-3 block">
-                Part {post.order} / {formatBlogDate(post.date)}
+                Part {index + 1} / {formatBlogDate(post.date)}
               </span>
               <span className="block text-[1.02rem] leading-8 text-slate-700">
                 {post.excerpt}

--- a/app/routes/blog.series.$slug.tsx
+++ b/app/routes/blog.series.$slug.tsx
@@ -1,3 +1,103 @@
+import type { LoaderFunctionArgs, MetaFunction } from "@remix-run/node"
+import { json } from "@remix-run/node"
+import { Link, useLoaderData } from "@remix-run/react"
+import { Card, PageTitle } from "~/components"
+import { formatBlogDate, getBlogSeriesBySlug } from "~/content/blog"
+import { cardStyles } from "~/utils/card-styles"
+import { buildPageMeta } from "~/utils/seo"
+
+type LoaderData = {
+  series: {
+    slug: string
+    title: string
+    posts: {
+      slug: string
+      title: string
+      excerpt: string
+      date: string
+      order?: number
+    }[]
+  }
+}
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const series = getBlogSeriesBySlug(params.slug ?? "")
+
+  if (!series) {
+    throw new Response("Not Found", { status: 404 })
+  }
+
+  return json<LoaderData>({
+    series: {
+      slug: series.slug,
+      title: series.title,
+      posts: series.posts.map((post) => ({
+        slug: post.slug,
+        title: post.title,
+        excerpt: post.excerpt,
+        date: post.date,
+        order: post.series?.order,
+      })),
+    },
+  })
+}
+
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  if (!data) {
+    return [
+      { title: "Blog Series" },
+      { name: "robots", content: "noindex" },
+    ]
+  }
+
+  return buildPageMeta({
+    title: data.series.title + " Series",
+    description: "Posts in the " + data.series.title + " series.",
+    path: "/blog/series/" + data.series.slug,
+  })
+}
+
 export default function BlogSeriesRoute() {
-  return <div>Series Route</div>
+  const { series } = useLoaderData<typeof loader>()
+
+  return (
+    <div className="space-y-10">
+      <div className="space-y-5">
+        <Link className="article-meta-link inline-flex text-sm" to="/blog">
+          Back to blog
+        </Link>
+        <PageTitle
+          title={series.title}
+          subtitle="Ordered notes and essays grouped as a connected series."
+        />
+      </div>
+
+      <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {series.posts.map((post, index) => (
+          <Card
+            key={post.slug}
+            title={post.title}
+            url={"/blog/" + post.slug}
+            headingLevel={2}
+            className={
+              index % 3 === 0
+                ? cardStyles.neutral + " editorial-card"
+                : index % 3 === 1
+                  ? cardStyles.blue + " editorial-card"
+                  : cardStyles.green + " editorial-card"
+            }
+          >
+            <>
+              <span className="meta-kicker mb-3 block">
+                Part {post.order} / {formatBlogDate(post.date)}
+              </span>
+              <span className="block text-[1.02rem] leading-8 text-slate-700">
+                {post.excerpt}
+              </span>
+            </>
+          </Card>
+        ))}
+      </section>
+    </div>
+  )
 }

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -13,8 +13,16 @@
 
 html {
   background:
-    radial-gradient(circle at top left, rgb(219 234 247 / 0.5), transparent 30%),
-    radial-gradient(circle at top right, rgb(211 228 222 / 0.4), transparent 32%),
+    radial-gradient(
+      circle at top left,
+      rgb(219 234 247 / 0.5),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at top right,
+      rgb(211 228 222 / 0.4),
+      transparent 32%
+    ),
     var(--brand-paper);
 }
 
@@ -200,8 +208,11 @@ details[open] > .mobile-nav-panel {
 }
 
 .editorial-panel {
-  background:
-    linear-gradient(180deg, rgb(255 255 255 / 0.88), rgb(248 250 252 / 0.88));
+  background: linear-gradient(
+    180deg,
+    rgb(255 255 255 / 0.88),
+    rgb(248 250 252 / 0.88)
+  );
   border: 1px solid rgb(226 232 240);
   border-radius: 1.75rem;
   box-shadow: 0 18px 36px rgb(31 42 42 / 0.08);
@@ -316,8 +327,7 @@ details[open] > .mobile-nav-panel {
 }
 
 .article-prose pre {
-  background:
-    linear-gradient(180deg, rgb(248 250 252), rgb(241 245 249));
+  background: linear-gradient(180deg, rgb(248 250 252), rgb(241 245 249));
   border: 1px solid rgb(203 213 225);
   border-radius: 1rem;
   box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.65);
@@ -380,8 +390,11 @@ details[open] > .mobile-nav-panel {
 }
 
 .article-diagram {
-  background:
-    linear-gradient(180deg, rgb(255 255 255 / 0.9), rgb(248 250 252 / 0.9));
+  background: linear-gradient(
+    180deg,
+    rgb(255 255 255 / 0.9),
+    rgb(248 250 252 / 0.9)
+  );
   border: 1px solid rgb(203 213 225);
   border-radius: 1.35rem;
   box-shadow: 0 18px 32px rgb(31 42 42 / 0.05);
@@ -389,6 +402,10 @@ details[open] > .mobile-nav-panel {
   margin-top: 1.5rem;
   max-width: 28rem;
   padding: 0.95rem;
+}
+
+.article-diagram[data-mermaid-diagram] {
+  width: 100%;
 }
 
 .article-diagram-caption {

--- a/content/blog/governance-native-engineering-control-plane.md
+++ b/content/blog/governance-native-engineering-control-plane.md
@@ -1,0 +1,85 @@
+---
+title: Governance-Native Engineering and the AI Control Plane
+publish: false
+summary: AI-native engineering shifts the bottleneck from implementation throughput toward governance, replayability, and organizational comprehension.
+tags:
+  - AI
+  - Anthesis
+  - Governance
+  - SDLC
+---
+
+# Governance-Native Engineering and the AI Control Plane
+
+AI-native engineering creates a control-plane problem.
+
+Generated code increases throughput, but without intent capture, evidence, review boundaries, replayability guarantees, and human comprehension loops, organizations accumulate technical, cognitive, and intent debt faster than they can repay it.
+
+## The Bottleneck Has Moved
+
+The bottleneck is no longer purely implementation throughput.
+
+It is increasingly:
+
+- governance
+- replayability
+- operational trust
+- organizational memory
+- reviewability
+- comprehension preservation
+
+Transport-compatible APIs and interchangeable model providers create operational flexibility, but they do not create governance equivalence.
+
+## The Governance Surface
+
+Inference-provider selection is not merely infrastructure configuration.
+
+It is a governance decision involving:
+
+- locality
+- retention
+- replayability
+- evidence quality
+- trust boundaries
+- policy constraints
+
+This suggests AI-native systems require governance-native architecture.
+
+## Anthesis Direction
+
+Anthesis treats:
+
+- prompts
+- execution
+- provider routing
+- replay evidence
+- workflow composition
+- approvals
+- policy evaluation
+
+as explicit governance surfaces.
+
+The goal is not to eliminate agents.
+
+The goal is to ensure humans remain capable of:
+
+- review
+- replay
+- intervention
+- attribution
+- governance
+
+while agents accelerate execution.
+
+## Draft Thesis
+
+The next generation of engineering systems will likely differentiate not on raw generation quality, but on:
+
+- governance clarity
+- replayability
+- organizational comprehensibility
+- bounded autonomy
+- evidence quality
+- intent preservation
+
+AI-native engineering therefore becomes a systems-governance discipline, not merely a prompting discipline.

--- a/content/blog/recursive-governance-and-agent-workflows.md
+++ b/content/blog/recursive-governance-and-agent-workflows.md
@@ -1,0 +1,109 @@
+---
+title: Recursive Governance and Agent Workflows
+publish: false
+summary: Recursive and hierarchical agent systems require governance boundaries, replay semantics, and observable execution surfaces.
+tags:
+  - AI
+  - Anthesis
+  - Recursive Systems
+  - Governance
+---
+
+# Recursive Governance and Agent Workflows
+
+Recursive agent systems are becoming increasingly attractive.
+
+Hierarchical planners, reviewer trees, recursive decomposition systems, and latent collaboration models promise better reasoning scalability than flat prompting alone.
+
+But recursive systems introduce governance problems.
+
+## The Core Tension
+
+Recursive systems can expand:
+
+- execution depth
+- execution fan-out
+- authority propagation
+- context contamination
+- replay ambiguity
+- provenance collapse
+
+faster than traditional orchestration systems were designed to handle.
+
+The challenge is therefore not only orchestration.
+
+It is governed recursion.
+
+## Observable vs Latent Execution
+
+Not all recursive execution is equally observable.
+
+Some systems expose:
+
+- explicit execution nodes
+- review boundaries
+- execution lineage
+- structured delegation
+
+Others operate partly in latent space or opaque runtime layers.
+
+Governance systems must distinguish between:
+
+- observable execution
+- opaque execution
+- latent execution
+- synthesized outputs
+
+without pretending complete introspection exists.
+
+## Replayability Boundaries
+
+Recursive systems complicate replayability.
+
+A workflow cannot claim stronger replay guarantees than the weakest materially contributing execution boundary.
+
+This creates a governed-delivery-path model:
+
+- advisory branches may remain excluded
+- synthesis-influencing branches become governance-relevant
+- latent recursive execution constrains replay ceilings
+
+Replayability therefore propagates across execution lineage.
+
+## Anthesis Direction
+
+Anthesis treats recursive coordination as:
+
+- profiles over governed execution graphs
+- bounded execution expansion
+- evidence-linked workflow composition
+- policy-governed delegation
+
+rather than unrestricted autonomous recursion.
+
+This preserves:
+
+- replayability
+- attribution
+- approvals
+- policy enforcement
+- reviewability
+- bounded authority
+
+while still allowing recursive coordination.
+
+## Governance-Native Recursion
+
+The long-term challenge is not simply building more capable recursive agents.
+
+It is ensuring humans remain capable of:
+
+- comprehension
+- intervention
+- replay
+- audit
+- authority governance
+
+after recursive systems become operationally useful.
+
+That likely requires governance-native recursive execution models rather than purely capability-native architectures.

--- a/content/blog/replayability-is-a-governance-problem.md
+++ b/content/blog/replayability-is-a-governance-problem.md
@@ -1,0 +1,99 @@
+---
+title: Replayability Is a Governance Problem
+publish: false
+summary: Replayability in AI-native systems is not just reproducibility engineering. It is governance infrastructure.
+tags:
+  - AI
+  - Replayability
+  - Governance
+  - Anthesis
+---
+
+# Replayability Is a Governance Problem
+
+Most conversations around AI reproducibility focus on determinism.
+
+But deterministic replay is only one small part of the problem.
+
+The larger issue is governance.
+
+## Replayability vs Reproducibility
+
+Traditional software systems often assume:
+
+- identical binaries
+- stable execution environments
+- deterministic inputs
+- recoverable runtime state
+
+AI systems violate many of those assumptions.
+
+Providers change.
+Models mutate.
+Routing changes.
+Retention windows expire.
+Metadata disappears.
+
+Replayability therefore becomes an evidence problem.
+
+## Replayability Ceilings
+
+Different inference providers support different replayability ceilings.
+
+A local deterministic runtime and a shared external provider may expose identical APIs while offering radically different replay guarantees.
+
+This means replayability must become:
+
+- explicit
+- policy-aware
+- evidence-backed
+- surfaced to governance systems
+
+rather than hidden behind SDK abstractions.
+
+## Replayability Decay
+
+Replayability is not static.
+
+It decays over time.
+
+Replay guarantees weaken as:
+
+- models are replaced
+- provider attestations expire
+- evidence is garbage-collected
+- execution metadata disappears
+- retention windows close
+
+Governance systems must model replayability degradation explicitly.
+
+## Anthesis Perspective
+
+Anthesis treats replayability as a first-class governance surface.
+
+Replay evidence is attached to:
+
+- workflow execution
+- provider routing
+- execution lineage
+- policy evaluation
+- governance signals
+
+The goal is not perfect determinism.
+
+The goal is bounded explainability and attributable execution.
+
+## The Emerging Discipline
+
+AI-native engineering systems will likely require:
+
+- replay envelopes
+- evidence taxonomies
+- locality evidence
+- provider trust semantics
+- governance-aware routing
+- human review boundaries
+
+Replayability is no longer merely a debugging concern.
+
+It is organizational infrastructure.

--- a/e2e/routes.spec.ts
+++ b/e2e/routes.spec.ts
@@ -84,6 +84,16 @@ test("/blog exposes the architecture notes index", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: "Blog" })).toBeVisible()
   await expect(
+    page.locator("a", {
+      has: page.getByRole("heading", {
+        name: "Governance-Native Engineering and the AI Control Plane",
+      }),
+    }),
+  ).toHaveAttribute(
+    "href",
+    "/blog/governance-native-engineering-control-plane",
+  )
+  await expect(
     page.getByRole("link", {
       name: "Secure Platform Integration Is Not Plumbing",
       exact: true,
@@ -94,6 +104,19 @@ test("/blog exposes the architecture notes index", async ({ page }) => {
       "Durable technical writing for proposals, partnerships, and delivery decisions.",
     ),
   ).toBeVisible()
+  await expect(
+    page
+      .locator(".editorial-card")
+      .getByText("Governance-Native Engineering", { exact: true }),
+  ).toHaveCount(3)
+  await expect(
+    page
+      .locator(".editorial-card")
+      .getByText("Architecture Control Boundaries", { exact: true }),
+  ).toHaveCount(3)
+  await expect(page.getByText("Part 1")).toHaveCount(2)
+  await expect(page.getByText("Part 2")).toHaveCount(2)
+  await expect(page.getByText("Part 3")).toHaveCount(2)
 })
 
 test("/blog/:slug exposes article content and related notes", async ({
@@ -112,10 +135,67 @@ test("/blog/:slug exposes article content and related notes", async ({
     ),
   ).toBeVisible()
   await expect(
-    page.getByRole("link", {
-      name: "Secure Platform Integration Is Not Plumbing",
-    }),
+    page
+      .getByRole("heading", { name: "Related notes" })
+      .locator("..")
+      .getByRole("link", {
+        name: /Secure Platform Integration Is Not Plumbing/,
+      }),
   ).toHaveAttribute("href", "/blog/secure-platform-integration-is-not-plumbing")
+})
+
+test("/blog/:slug exposes series navigation for governance-native posts", async ({
+  page,
+}) => {
+  await page.goto("/blog/governance-native-engineering-control-plane")
+
+  await expect(
+    page.getByRole("heading", {
+      name: "Governance-Native Engineering and the AI Control Plane",
+    }),
+  ).toBeVisible()
+  await expect(
+    page.getByRole("link", {
+      name: "Governance-Native Engineering",
+      exact: true,
+    }),
+  ).toHaveAttribute("href", "/blog/series/governance-native-engineering")
+  await expect(page.getByText("Part 1 of 3")).toBeVisible()
+  await expect(
+    page.getByRole("link", {
+      name: "Next: Replayability Is a Governance Problem",
+    }),
+  ).toHaveAttribute("href", "/blog/replayability-is-a-governance-problem")
+})
+
+test("/blog/series/:slug exposes ordered series posts", async ({ page }) => {
+  await page.goto("/blog/series/governance-native-engineering")
+
+  await expect(
+    page.getByRole("heading", {
+      name: "Governance-Native Engineering",
+      exact: true,
+    }),
+  ).toBeVisible()
+  await expect(
+    page.getByRole("link", {
+      name: "Governance-Native Engineering and the AI Control Plane",
+    }),
+  ).toHaveAttribute(
+    "href",
+    "/blog/governance-native-engineering-control-plane",
+  )
+  await expect(
+    page.getByRole("link", { name: "Replayability Is a Governance Problem" }),
+  ).toHaveAttribute("href", "/blog/replayability-is-a-governance-problem")
+  await expect(
+    page.getByRole("link", {
+      name: "Recursive Governance and Agent Workflows",
+    }),
+  ).toHaveAttribute("href", "/blog/recursive-governance-and-agent-workflows")
+  await expect(page.getByText(/Part 1 \/ May 18, 2026/)).toBeVisible()
+  await expect(page.getByText(/Part 2 \/ May 18, 2026/)).toBeVisible()
+  await expect(page.getByText(/Part 3 \/ May 18, 2026/)).toBeVisible()
 })
 
 test("/blog posts expose their diagram images", async ({ page }) => {

--- a/e2e/structured-data.spec.ts
+++ b/e2e/structured-data.spec.ts
@@ -101,14 +101,23 @@ test("/blog exposes CollectionPage structured data", async ({ page }) => {
   expect(collectionPage).toBeTruthy()
   expect(collectionPage?.name).toBe("Blog")
   expect(collectionPage?.mainEntity?.["@type"]).toBe("ItemList")
-  expect(collectionPage?.mainEntity?.numberOfItems).toBe(3)
+  expect(collectionPage?.mainEntity?.numberOfItems).toBe(6)
   expect(collectionPage?.mainEntity?.itemListElement?.[0]?.item?.name).toBe(
-    "Secure Platform Integration Is Not Plumbing",
+    "Governance-Native Engineering and the AI Control Plane",
   )
   expect(collectionPage?.mainEntity?.itemListElement?.[1]?.item?.name).toBe(
-    "AI Pipelines Need Control Boundaries",
+    "Replayability Is a Governance Problem",
   )
   expect(collectionPage?.mainEntity?.itemListElement?.[2]?.item?.name).toBe(
+    "Recursive Governance and Agent Workflows",
+  )
+  expect(collectionPage?.mainEntity?.itemListElement?.[3]?.item?.name).toBe(
+    "Secure Platform Integration Is Not Plumbing",
+  )
+  expect(collectionPage?.mainEntity?.itemListElement?.[4]?.item?.name).toBe(
+    "AI Pipelines Need Control Boundaries",
+  )
+  expect(collectionPage?.mainEntity?.itemListElement?.[5]?.item?.name).toBe(
     "Software Layers Are Risk Boundaries",
   )
 })

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@remix-run/react": "2.17.4",
     "@remix-run/serve": "2.17.4",
     "isbot": "^4",
+    "mermaid": "^11.12.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-websitecarbon-badge": "^1.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@antfu/install-pkg@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@antfu/install-pkg/-/install-pkg-1.1.0.tgz#78fa036be1a6081b5a77a5cf59f50c7752b6ba26"
+  integrity sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==
+  dependencies:
+    package-manager-detector "^1.3.0"
+    tinyexec "^1.0.1"
+
 "@axe-core/playwright@^4.10.2":
   version "4.11.1"
   resolved "https://registry.yarnpkg.com/@axe-core/playwright/-/playwright-4.11.1.tgz#d6e2b06ddb1b8ff460ca0f6f0bc96f2f03f6d91b"
@@ -314,6 +322,16 @@
   dependencies:
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
+
+"@braintree/sanitize-url@^7.1.1":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz#ca2035b0fefe956a8676ff0c69af73e605fcd81f"
+  integrity sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==
+
+"@chevrotain/types@~11.1.1":
+  version "11.1.2"
+  resolved "https://registry.yarnpkg.com/@chevrotain/types/-/types-11.1.2.tgz#e83a1a2704f0c5e49e7592b214031a0f4a34d7e5"
+  integrity sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==
 
 "@emnapi/core@^1.4.3", "@emnapi/core@^1.7.1":
   version "1.7.1"
@@ -968,6 +986,20 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
+"@iconify/types@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@iconify/types/-/types-2.0.0.tgz#ab0e9ea681d6c8a1214f30cd741fe3a20cc57f57"
+  integrity sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==
+
+"@iconify/utils@^3.0.2":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@iconify/utils/-/utils-3.1.3.tgz#71efd68f9ed2ea3c91fd3a01c0032f70a87027b7"
+  integrity sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==
+  dependencies:
+    "@antfu/install-pkg" "^1.1.0"
+    "@iconify/types" "^2.0.0"
+    import-meta-resolve "^4.2.0"
+
 "@isaacs/balanced-match@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz#3081dadbc3460661b751e7591d7faea5df39dd29"
@@ -1053,6 +1085,13 @@
     unist-util-stringify-position "^3.0.0"
     unist-util-visit "^4.0.0"
     vfile "^5.0.0"
+
+"@mermaid-js/parser@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@mermaid-js/parser/-/parser-1.1.1.tgz#30f3ab68d816912e43f245a72a0d4081bf69d966"
+  integrity sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==
+  dependencies:
+    "@chevrotain/types" "~11.1.1"
 
 "@napi-rs/wasm-runtime@^0.2.11":
   version "0.2.12"
@@ -1711,6 +1750,216 @@
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.6.0.tgz#eac397f28bf1d6ae0ae081363eca2f425bedf0d5"
   integrity sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==
 
+"@types/d3-array@*":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-array/-/d3-array-3.2.2.tgz#e02151464d02d4a1b44646d0fcdb93faf88fde8c"
+  integrity sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==
+
+"@types/d3-axis@*":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-axis/-/d3-axis-3.0.6.tgz#e760e5765b8188b1defa32bc8bb6062f81e4c795"
+  integrity sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-brush@*":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-brush/-/d3-brush-3.0.6.tgz#c2f4362b045d472e1b186cdbec329ba52bdaee6c"
+  integrity sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-chord@*":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-chord/-/d3-chord-3.0.6.tgz#1706ca40cf7ea59a0add8f4456efff8f8775793d"
+  integrity sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==
+
+"@types/d3-color@*":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-3.1.3.tgz#368c961a18de721da8200e80bf3943fb53136af2"
+  integrity sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==
+
+"@types/d3-contour@*":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-contour/-/d3-contour-3.0.6.tgz#9ada3fa9c4d00e3a5093fed0356c7ab929604231"
+  integrity sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==
+  dependencies:
+    "@types/d3-array" "*"
+    "@types/geojson" "*"
+
+"@types/d3-delaunay@*":
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz#185c1a80cc807fdda2a3fe960f7c11c4a27952e1"
+  integrity sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==
+
+"@types/d3-dispatch@*":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz#ef004d8a128046cfce434d17182f834e44ef95b2"
+  integrity sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==
+
+"@types/d3-drag@*":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-drag/-/d3-drag-3.0.7.tgz#b13aba8b2442b4068c9a9e6d1d82f8bcea77fc02"
+  integrity sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-dsv@*":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-dsv/-/d3-dsv-3.0.7.tgz#0a351f996dc99b37f4fa58b492c2d1c04e3dac17"
+  integrity sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==
+
+"@types/d3-ease@*":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-ease/-/d3-ease-3.0.2.tgz#e28db1bfbfa617076f7770dd1d9a48eaa3b6c51b"
+  integrity sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==
+
+"@types/d3-fetch@*":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-fetch/-/d3-fetch-3.0.7.tgz#c04a2b4f23181aa376f30af0283dbc7b3b569980"
+  integrity sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==
+  dependencies:
+    "@types/d3-dsv" "*"
+
+"@types/d3-force@*":
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/@types/d3-force/-/d3-force-3.0.10.tgz#6dc8fc6e1f35704f3b057090beeeb7ac674bff1a"
+  integrity sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==
+
+"@types/d3-format@*":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-format/-/d3-format-3.0.4.tgz#b1e4465644ddb3fdf3a263febb240a6cd616de90"
+  integrity sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==
+
+"@types/d3-geo@*":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-geo/-/d3-geo-3.1.0.tgz#b9e56a079449174f0a2c8684a9a4df3f60522440"
+  integrity sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==
+  dependencies:
+    "@types/geojson" "*"
+
+"@types/d3-hierarchy@*":
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz#6023fb3b2d463229f2d680f9ac4b47466f71f17b"
+  integrity sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==
+
+"@types/d3-interpolate@*":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz#412b90e84870285f2ff8a846c6eb60344f12a41c"
+  integrity sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==
+  dependencies:
+    "@types/d3-color" "*"
+
+"@types/d3-path@*":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-3.1.1.tgz#f632b380c3aca1dba8e34aa049bcd6a4af23df8a"
+  integrity sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==
+
+"@types/d3-polygon@*":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-polygon/-/d3-polygon-3.0.2.tgz#dfae54a6d35d19e76ac9565bcb32a8e54693189c"
+  integrity sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==
+
+"@types/d3-quadtree@*":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz#d4740b0fe35b1c58b66e1488f4e7ed02952f570f"
+  integrity sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==
+
+"@types/d3-random@*":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-random/-/d3-random-3.0.3.tgz#ed995c71ecb15e0cd31e22d9d5d23942e3300cfb"
+  integrity sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==
+
+"@types/d3-scale-chromatic@*":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz#dc6d4f9a98376f18ea50bad6c39537f1b5463c39"
+  integrity sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==
+
+"@types/d3-scale@*":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-4.0.9.tgz#57a2f707242e6fe1de81ad7bfcccaaf606179afb"
+  integrity sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==
+  dependencies:
+    "@types/d3-time" "*"
+
+"@types/d3-selection@*":
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/@types/d3-selection/-/d3-selection-3.0.11.tgz#bd7a45fc0a8c3167a631675e61bc2ca2b058d4a3"
+  integrity sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==
+
+"@types/d3-shape@*":
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-3.1.8.tgz#d1516cc508753be06852cd06758e3bb54a22b0e3"
+  integrity sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==
+  dependencies:
+    "@types/d3-path" "*"
+
+"@types/d3-time-format@*":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-time-format/-/d3-time-format-4.0.3.tgz#d6bc1e6b6a7db69cccfbbdd4c34b70632d9e9db2"
+  integrity sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==
+
+"@types/d3-time@*":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.4.tgz#8472feecd639691450dd8000eb33edd444e1323f"
+  integrity sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==
+
+"@types/d3-timer@*":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-timer/-/d3-timer-3.0.2.tgz#70bbda77dc23aa727413e22e214afa3f0e852f70"
+  integrity sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==
+
+"@types/d3-transition@*":
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/@types/d3-transition/-/d3-transition-3.0.9.tgz#1136bc57e9ddb3c390dccc9b5ff3b7d2b8d94706"
+  integrity sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-zoom@*":
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/@types/d3-zoom/-/d3-zoom-3.0.8.tgz#dccb32d1c56b1e1c6e0f1180d994896f038bc40b"
+  integrity sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==
+  dependencies:
+    "@types/d3-interpolate" "*"
+    "@types/d3-selection" "*"
+
+"@types/d3@^7.4.3":
+  version "7.4.3"
+  resolved "https://registry.yarnpkg.com/@types/d3/-/d3-7.4.3.tgz#d4550a85d08f4978faf0a4c36b848c61eaac07e2"
+  integrity sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==
+  dependencies:
+    "@types/d3-array" "*"
+    "@types/d3-axis" "*"
+    "@types/d3-brush" "*"
+    "@types/d3-chord" "*"
+    "@types/d3-color" "*"
+    "@types/d3-contour" "*"
+    "@types/d3-delaunay" "*"
+    "@types/d3-dispatch" "*"
+    "@types/d3-drag" "*"
+    "@types/d3-dsv" "*"
+    "@types/d3-ease" "*"
+    "@types/d3-fetch" "*"
+    "@types/d3-force" "*"
+    "@types/d3-format" "*"
+    "@types/d3-geo" "*"
+    "@types/d3-hierarchy" "*"
+    "@types/d3-interpolate" "*"
+    "@types/d3-path" "*"
+    "@types/d3-polygon" "*"
+    "@types/d3-quadtree" "*"
+    "@types/d3-random" "*"
+    "@types/d3-scale" "*"
+    "@types/d3-scale-chromatic" "*"
+    "@types/d3-selection" "*"
+    "@types/d3-shape" "*"
+    "@types/d3-time" "*"
+    "@types/d3-time-format" "*"
+    "@types/d3-timer" "*"
+    "@types/d3-transition" "*"
+    "@types/d3-zoom" "*"
+
 "@types/debug@^4.0.0":
   version "4.1.12"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.12.tgz#a155f21690871953410df4b6b6f53187f0500917"
@@ -1729,6 +1978,11 @@
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
+
+"@types/geojson@*":
+  version "7946.0.16"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.16.tgz#8ebe53d69efada7044454e3305c19017d97ced2a"
+  integrity sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==
 
 "@types/hast@^2.0.0":
   version "2.3.10"
@@ -1800,6 +2054,11 @@
   version "7.7.1"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.7.1.tgz#3ce3af1a5524ef327d2da9e4fd8b6d95c8d70528"
   integrity sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==
+
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
 
 "@types/unist@^2", "@types/unist@^2.0.0":
   version "2.0.11"
@@ -2082,6 +2341,14 @@
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz#538b1e103bf8d9864e7b85cc96fa8d6fb6c40777"
   integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
+
+"@upsetjs/venn.js@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@upsetjs/venn.js/-/venn.js-2.0.0.tgz#3be192038cdda927aa4f8b22ab51af82abf47f34"
+  integrity sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==
+  optionalDependencies:
+    d3-selection "^3.0.0"
+    d3-transition "^3.0.1"
 
 "@vanilla-extract/babel-plugin-debug-ids@^1.0.4":
   version "1.2.2"
@@ -2714,6 +2981,16 @@ comma-separated-tokens@^2.0.0:
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz#4e89c9458acb61bc8fef19f4529973b2392839ee"
   integrity sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==
 
+commander@7:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+
+commander@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
+  integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
+
 compressible@~2.0.18:
   version "2.0.18"
   resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.18.tgz#af53cca6b070d4c3c0750fbd77286a6d7cc46fba"
@@ -2791,6 +3068,20 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
+cose-base@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/cose-base/-/cose-base-1.0.3.tgz#650334b41b869578a543358b80cda7e0abe0a60a"
+  integrity sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==
+  dependencies:
+    layout-base "^1.0.0"
+
+cose-base@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cose-base/-/cose-base-2.2.0.tgz#1c395c35b6e10bb83f9769ca8b817d614add5c01"
+  integrity sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==
+  dependencies:
+    layout-base "^2.0.0"
+
 cross-spawn@^6.0.5:
   version "6.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.6.tgz#30d0efa0712ddb7eb5a76e1e8721bffafa6b5d57"
@@ -2845,6 +3136,304 @@ csstype@^3.2.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.2.3.tgz#ec48c0f3e993e50648c86da559e2610995cf989a"
   integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
 
+cytoscape-cose-bilkent@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz#762fa121df9930ffeb51a495d87917c570ac209b"
+  integrity sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==
+  dependencies:
+    cose-base "^1.0.0"
+
+cytoscape-fcose@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz#e4d6f6490df4fab58ae9cea9e5c3ab8d7472f471"
+  integrity sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==
+  dependencies:
+    cose-base "^2.2.0"
+
+cytoscape@^3.33.1:
+  version "3.33.3"
+  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.33.3.tgz#6c885823cb088eb8c31087c35d978661dcde5eae"
+  integrity sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==
+
+"d3-array@1 - 2":
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.12.1.tgz#e20b41aafcdffdf5d50928004ececf815a465e81"
+  integrity sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==
+  dependencies:
+    internmap "^1.0.0"
+
+"d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3, d3-array@^3.2.0:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.4.tgz#15fec33b237f97ac5d7c986dc77da273a8ed0bb5"
+  integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
+  dependencies:
+    internmap "1 - 2"
+
+d3-axis@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-3.0.0.tgz#c42a4a13e8131d637b745fc2973824cfeaf93322"
+  integrity sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==
+
+d3-brush@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-3.0.0.tgz#6f767c4ed8dcb79de7ede3e1c0f89e63ef64d31c"
+  integrity sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-drag "2 - 3"
+    d3-interpolate "1 - 3"
+    d3-selection "3"
+    d3-transition "3"
+
+d3-chord@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-3.0.1.tgz#d156d61f485fce8327e6abf339cb41d8cbba6966"
+  integrity sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==
+  dependencies:
+    d3-path "1 - 3"
+
+"d3-color@1 - 3", d3-color@3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
+
+d3-contour@4:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-4.0.2.tgz#bb92063bc8c5663acb2422f99c73cbb6c6ae3bcc"
+  integrity sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==
+  dependencies:
+    d3-array "^3.2.0"
+
+d3-delaunay@6:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/d3-delaunay/-/d3-delaunay-6.0.4.tgz#98169038733a0a5babbeda55054f795bb9e4a58b"
+  integrity sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==
+  dependencies:
+    delaunator "5"
+
+"d3-dispatch@1 - 3", d3-dispatch@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-3.0.1.tgz#5fc75284e9c2375c36c839411a0cf550cbfc4d5e"
+  integrity sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==
+
+"d3-drag@2 - 3", d3-drag@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-3.0.0.tgz#994aae9cd23c719f53b5e10e3a0a6108c69607ba"
+  integrity sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-selection "3"
+
+"d3-dsv@1 - 3", d3-dsv@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-3.0.1.tgz#c63af978f4d6a0d084a52a673922be2160789b73"
+  integrity sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==
+  dependencies:
+    commander "7"
+    iconv-lite "0.6"
+    rw "1"
+
+"d3-ease@1 - 3", d3-ease@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-3.0.1.tgz#9658ac38a2140d59d346160f1f6c30fda0bd12f4"
+  integrity sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==
+
+d3-fetch@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-fetch/-/d3-fetch-3.0.1.tgz#83141bff9856a0edb5e38de89cdcfe63d0a60a22"
+  integrity sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==
+  dependencies:
+    d3-dsv "1 - 3"
+
+d3-force@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-3.0.0.tgz#3e2ba1a61e70888fe3d9194e30d6d14eece155c4"
+  integrity sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-quadtree "1 - 3"
+    d3-timer "1 - 3"
+
+"d3-format@1 - 3", d3-format@3:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.2.tgz#01fdb46b58beb1f55b10b42ad70b6e344d5eb2ae"
+  integrity sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==
+
+d3-geo@3:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-3.1.1.tgz#6027cf51246f9b2ebd64f99e01dc7c3364033a4d"
+  integrity sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==
+  dependencies:
+    d3-array "2.5.0 - 3"
+
+d3-hierarchy@3:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz#b01cd42c1eed3d46db77a5966cf726f8c09160c6"
+  integrity sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==
+
+"d3-interpolate@1 - 3", "d3-interpolate@1.2.0 - 3", d3-interpolate@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
+  integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
+  dependencies:
+    d3-color "1 - 3"
+
+d3-path@1:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.9.tgz#48c050bb1fe8c262493a8caf5524e3e9591701cf"
+  integrity sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==
+
+"d3-path@1 - 3", d3-path@3, d3-path@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-3.1.0.tgz#22df939032fb5a71ae8b1800d61ddb7851c42526"
+  integrity sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==
+
+d3-polygon@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-polygon/-/d3-polygon-3.0.1.tgz#0b45d3dd1c48a29c8e057e6135693ec80bf16398"
+  integrity sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==
+
+"d3-quadtree@1 - 3", d3-quadtree@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-3.0.1.tgz#6dca3e8be2b393c9a9d514dabbd80a92deef1a4f"
+  integrity sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==
+
+d3-random@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-3.0.1.tgz#d4926378d333d9c0bfd1e6fa0194d30aebaa20f4"
+  integrity sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==
+
+d3-sankey@^0.12.3:
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/d3-sankey/-/d3-sankey-0.12.3.tgz#b3c268627bd72e5d80336e8de6acbfec9d15d01d"
+  integrity sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==
+  dependencies:
+    d3-array "1 - 2"
+    d3-shape "^1.2.0"
+
+d3-scale-chromatic@3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz#34c39da298b23c20e02f1a4b239bd0f22e7f1314"
+  integrity sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==
+  dependencies:
+    d3-color "1 - 3"
+    d3-interpolate "1 - 3"
+
+d3-scale@4:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-4.0.2.tgz#82b38e8e8ff7080764f8dcec77bd4be393689396"
+  integrity sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
+  dependencies:
+    d3-array "2.10.0 - 3"
+    d3-format "1 - 3"
+    d3-interpolate "1.2.0 - 3"
+    d3-time "2.1.1 - 3"
+    d3-time-format "2 - 4"
+
+"d3-selection@2 - 3", d3-selection@3, d3-selection@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-3.0.0.tgz#c25338207efa72cc5b9bd1458a1a41901f1e1b31"
+  integrity sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==
+
+d3-shape@3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-3.2.0.tgz#a1a839cbd9ba45f28674c69d7f855bcf91dfc6a5"
+  integrity sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==
+  dependencies:
+    d3-path "^3.1.0"
+
+d3-shape@^1.2.0:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.7.tgz#df63801be07bc986bc54f63789b4fe502992b5d7"
+  integrity sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
+  dependencies:
+    d3-path "1"
+
+"d3-time-format@2 - 4", d3-time-format@4:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-4.1.0.tgz#7ab5257a5041d11ecb4fe70a5c7d16a195bb408a"
+  integrity sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
+  dependencies:
+    d3-time "1 - 3"
+
+"d3-time@1 - 3", "d3-time@2.1.1 - 3", d3-time@3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-3.1.0.tgz#9310db56e992e3c0175e1ef385e545e48a9bb5c7"
+  integrity sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==
+  dependencies:
+    d3-array "2 - 3"
+
+"d3-timer@1 - 3", d3-timer@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
+  integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
+
+"d3-transition@2 - 3", d3-transition@3, d3-transition@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-3.0.1.tgz#6869fdde1448868077fdd5989200cb61b2a1645f"
+  integrity sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==
+  dependencies:
+    d3-color "1 - 3"
+    d3-dispatch "1 - 3"
+    d3-ease "1 - 3"
+    d3-interpolate "1 - 3"
+    d3-timer "1 - 3"
+
+d3-zoom@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-3.0.0.tgz#d13f4165c73217ffeaa54295cd6969b3e7aee8f3"
+  integrity sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-drag "2 - 3"
+    d3-interpolate "1 - 3"
+    d3-selection "2 - 3"
+    d3-transition "2 - 3"
+
+d3@^7.9.0:
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/d3/-/d3-7.9.0.tgz#579e7acb3d749caf8860bd1741ae8d371070cd5d"
+  integrity sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==
+  dependencies:
+    d3-array "3"
+    d3-axis "3"
+    d3-brush "3"
+    d3-chord "3"
+    d3-color "3"
+    d3-contour "4"
+    d3-delaunay "6"
+    d3-dispatch "3"
+    d3-drag "3"
+    d3-dsv "3"
+    d3-ease "3"
+    d3-fetch "3"
+    d3-force "3"
+    d3-format "3"
+    d3-geo "3"
+    d3-hierarchy "3"
+    d3-interpolate "3"
+    d3-path "3"
+    d3-polygon "3"
+    d3-quadtree "3"
+    d3-random "3"
+    d3-scale "4"
+    d3-scale-chromatic "3"
+    d3-selection "3"
+    d3-shape "3"
+    d3-time "3"
+    d3-time-format "4"
+    d3-timer "3"
+    d3-transition "3"
+    d3-zoom "3"
+
+dagre-d3-es@7.0.14:
+  version "7.0.14"
+  resolved "https://registry.yarnpkg.com/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz#1272276e26457cf3b97dac569f8f0531ec33c377"
+  integrity sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==
+  dependencies:
+    d3 "^7.9.0"
+    lodash-es "^4.17.21"
+
 damerau-levenshtein@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
@@ -2881,6 +3470,11 @@ data-view-byte-offset@^1.0.1:
     call-bound "^1.0.2"
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
+
+dayjs@^1.11.19:
+  version "1.11.20"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.20.tgz#88d919fd639dc991415da5f4cb6f1b6650811938"
+  integrity sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==
 
 debug@2.6.9:
   version "2.6.9"
@@ -2979,6 +3573,13 @@ define-properties@^1.1.3, define-properties@^1.2.1:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
 
+delaunator@5:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-5.1.0.tgz#d13271fbf3aff6753f9ea6e235557f20901046ea"
+  integrity sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==
+  dependencies:
+    robust-predicates "^3.0.2"
+
 depd@2.0.0, depd@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
@@ -3027,6 +3628,13 @@ dom-accessibility-api@^0.5.9:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
   integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
+
+dompurify@^3.3.1:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.5.tgz#bedc7d30a6007ae9a8937b952be6adb76a28e871"
+  integrity sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 dotenv@^16.0.0:
   version "16.6.1"
@@ -3258,6 +3866,11 @@ es-to-primitive@^1.3.0:
     is-callable "^1.2.7"
     is-date-object "^1.0.5"
     is-symbol "^1.0.4"
+
+es-toolkit@^1.45.1:
+  version "1.46.1"
+  resolved "https://registry.yarnpkg.com/es-toolkit/-/es-toolkit-1.46.1.tgz#38ca27191a98a867fc544b81cf1477a68947fb06"
+  integrity sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==
 
 esbuild-plugins-node-modules-polyfill@^1.6.0:
   version "1.7.1"
@@ -4171,6 +4784,11 @@ gunzip-maybe@^1.4.2:
     pumpify "^1.3.3"
     through2 "^2.0.3"
 
+hachure-fill@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/hachure-fill/-/hachure-fill-0.5.2.tgz#d19bc4cc8750a5962b47fb1300557a85fcf934cc"
+  integrity sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==
+
 has-bigints@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.1.0.tgz#28607e965ac967e03cd2a2c70a2636a1edad49fe"
@@ -4287,6 +4905,13 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+iconv-lite@0.6:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 icss-utils@^5.0.0, icss-utils@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
@@ -4314,6 +4939,11 @@ import-fresh@^3.2.1:
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
+
+import-meta-resolve@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz#08cb85b5bd37ecc8eb1e0f670dc2767002d43734"
+  integrity sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -4343,6 +4973,16 @@ internal-slot@^1.1.0:
     es-errors "^1.3.0"
     hasown "^2.0.2"
     side-channel "^1.1.0"
+
+"internmap@1 - 2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
+  integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
+
+internmap@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/internmap/-/internmap-1.0.1.tgz#0017cc8a3b99605f0302f2b198d272e015e5df95"
+  integrity sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==
 
 ipaddr.js@1.9.1:
   version "1.9.1"
@@ -4763,12 +5403,24 @@ jsonfile@^6.0.1:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
+katex@^0.16.25:
+  version "0.16.47"
+  resolved "https://registry.yarnpkg.com/katex/-/katex-0.16.47.tgz#0a13a42c2deb4f74e61f162d440b9165a548030f"
+  integrity sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==
+  dependencies:
+    commander "^8.3.0"
+
 keyv@^4.5.4:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
   integrity sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
   dependencies:
     json-buffer "3.0.1"
+
+khroma@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/khroma/-/khroma-2.1.0.tgz#45f2ce94ce231a437cf5b63c2e886e6eb42bbbb1"
+  integrity sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==
 
 kleur@^4.0.3:
   version "4.1.5"
@@ -4786,6 +5438,16 @@ language-tags@^1.0.9:
   integrity sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==
   dependencies:
     language-subtag-registry "^0.3.20"
+
+layout-base@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/layout-base/-/layout-base-1.0.2.tgz#1291e296883c322a9dd4c5dd82063721b53e26e2"
+  integrity sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==
+
+layout-base@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/layout-base/-/layout-base-2.0.1.tgz#d0337913586c90f9c2c075292069f5c2da5dd285"
+  integrity sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==
 
 levn@^0.4.1:
   version "0.4.1"
@@ -4905,6 +5567,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash-es@^4.17.21:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
+  integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
+
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
@@ -4978,6 +5645,11 @@ markdown-extensions@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/markdown-extensions/-/markdown-extensions-1.1.1.tgz#fea03b539faeaee9b4ef02a3769b455b189f7fc3"
   integrity sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q==
+
+marked@^16.3.0:
+  version "16.4.2"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-16.4.2.tgz#4959a64be6c486f0db7467ead7ce288de54290a3"
+  integrity sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==
 
 math-intrinsics@^1.1.0:
   version "1.1.0"
@@ -5145,6 +5817,33 @@ merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+mermaid@^11.12.1:
+  version "11.15.0"
+  resolved "https://registry.yarnpkg.com/mermaid/-/mermaid-11.15.0.tgz#b485c13ea5e1e74f3328c4bb00427bda87fa1c1e"
+  integrity sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==
+  dependencies:
+    "@braintree/sanitize-url" "^7.1.1"
+    "@iconify/utils" "^3.0.2"
+    "@mermaid-js/parser" "^1.1.1"
+    "@types/d3" "^7.4.3"
+    "@upsetjs/venn.js" "^2.0.0"
+    cytoscape "^3.33.1"
+    cytoscape-cose-bilkent "^4.1.0"
+    cytoscape-fcose "^2.2.0"
+    d3 "^7.9.0"
+    d3-sankey "^0.12.3"
+    dagre-d3-es "7.0.14"
+    dayjs "^1.11.19"
+    dompurify "^3.3.1"
+    es-toolkit "^1.45.1"
+    katex "^0.16.25"
+    khroma "^2.1.0"
+    marked "^16.3.0"
+    roughjs "^4.6.6"
+    stylis "^4.3.6"
+    ts-dedent "^2.2.0"
+    uuid "^11.1.0 || ^12 || ^13 || ^14.0.0"
 
 methods@~1.1.2:
   version "1.1.2"
@@ -5917,6 +6616,11 @@ package-json-from-dist@^1.0.0:
   resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
   integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
 
+package-manager-detector@^1.3.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/package-manager-detector/-/package-manager-detector-1.6.0.tgz#70d0cf0aa02c877eeaf66c4d984ede0be9130734"
+  integrity sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==
+
 pako@~0.2.0:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
@@ -5959,6 +6663,11 @@ parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
+
+path-data-parser@0.1.0, path-data-parser@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/path-data-parser/-/path-data-parser-0.1.0.tgz#8f5ba5cc70fc7becb3dcefaea08e2659aba60b8c"
+  integrity sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -6094,6 +6803,19 @@ playwright@1.58.2:
     playwright-core "1.58.2"
   optionalDependencies:
     fsevents "2.3.2"
+
+points-on-curve@0.2.0, points-on-curve@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/points-on-curve/-/points-on-curve-0.2.0.tgz#7dbb98c43791859434284761330fa893cb81b4d1"
+  integrity sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==
+
+points-on-path@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/points-on-path/-/points-on-path-0.2.1.tgz#553202b5424c53bed37135b318858eacff85dd52"
+  integrity sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==
+  dependencies:
+    path-data-parser "0.1.0"
+    points-on-curve "0.2.0"
 
 possible-typed-array-names@^1.0.0:
   version "1.1.0"
@@ -6556,6 +7278,11 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.1.0.tgz#0fe13b9522e1473f51b558ee796e08f11f9b489f"
   integrity sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==
 
+robust-predicates@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/robust-predicates/-/robust-predicates-3.0.3.tgz#1099061b3349e2c5abec6c2ab0acd440d24d4062"
+  integrity sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==
+
 rollup@^4.20.0, rollup@^4.43.0:
   version "4.53.2"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.53.2.tgz#98e73ee51e119cb9d88b07d026c959522416420a"
@@ -6587,12 +7314,27 @@ rollup@^4.20.0, rollup@^4.43.0:
     "@rollup/rollup-win32-x64-msvc" "4.53.2"
     fsevents "~2.3.2"
 
+roughjs@^4.6.6:
+  version "4.6.6"
+  resolved "https://registry.yarnpkg.com/roughjs/-/roughjs-4.6.6.tgz#1059f49a5e0c80dee541a005b20cc322b222158b"
+  integrity sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==
+  dependencies:
+    hachure-fill "^0.5.2"
+    path-data-parser "^0.1.0"
+    points-on-curve "^0.2.0"
+    points-on-path "^0.2.1"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+rw@1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
+  integrity sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==
 
 sade@^1.7.3:
   version "1.8.1"
@@ -6639,7 +7381,7 @@ safe-regex-test@^1.0.3, safe-regex-test@^1.1.0:
     es-errors "^1.3.0"
     is-regex "^1.2.1"
 
-"safer-buffer@>= 2.1.2 < 3":
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -7110,6 +7852,11 @@ styled-components@^5.3.3:
     shallowequal "^1.1.0"
     supports-color "^5.5.0"
 
+stylis@^4.3.6:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.4.0.tgz#c5846c9345f4bfc51bd0cbd7ca35a0744f485a5d"
+  integrity sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==
+
 supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -7187,6 +7934,11 @@ through2@^2.0.3:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
+tinyexec@^1.0.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-1.1.2.tgz#11feef204b706d4668ca4013db29f3bd64f5c4dc"
+  integrity sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==
+
 tinyglobby@^0.2.13, tinyglobby@^0.2.15:
   version "0.2.15"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.15.tgz#e228dd1e638cea993d2fdb4fcd2d4602a79951c2"
@@ -7226,6 +7978,11 @@ ts-api-utils@^2.4.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.5.0.tgz#4acd4a155e22734990a5ed1fe9e97f113bcb37c1"
   integrity sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==
+
+ts-dedent@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.2.0.tgz#39e4bd297cd036292ae2394eb3412be63f563bb5"
+  integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
 
 tsconfig-paths@^3.15.0:
   version "3.15.0"
@@ -7525,6 +8282,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
+
+"uuid@^11.1.0 || ^12 || ^13 || ^14.0.0":
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
+  integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
 
 uvu@^0.5.0:
   version "0.5.6"


### PR DESCRIPTION
## Summary

Adds Remix-native support for grouping blog posts into ordered series.

## Changes

- Adds optional `series` metadata to `BlogPost`
- Adds series grouping and lookup helpers
- Adds previous/next series navigation for individual blog posts
- Adds an ordered "In this series" section on posts
- Adds `/blog/series/:slug` landing route for series pages

## Notes

- This branch wires the data model and UI affordances for series support
- Follow-up recommended: surface series cards on the blog index and add structured-data relationships
- Build/typecheck should be run locally or in CI before merge

## Test plan

- Visit an existing non-series blog post and confirm it renders normally
- Add `series` metadata to posts and verify:
  - Part X of Y appears on post pages
  - previous/next links render correctly
  - `/blog/series/<slug>` renders ordered posts
