### PR TITLE
Render homepage projects from canonical catalog

### DIFF
--- a/app/data/project-catalog.ts
+++ b/app/data/project-catalog.ts
@@ -17,6 +17,13 @@ export type ProjectDefinition = {
   architectureRole: string
 }
 
+export const projectCollectionDescriptions = {
+  solution:
+    "Micrantha deployable systems, distributions, tools, and platforms for governed agentic development, mobile engineering, and secure delivery.",
+  laboratory:
+    "Micrantha testbeds and experimental projects that validate contracts, integrations, and emerging engineering capabilities.",
+} as const satisfies Record<ProjectClassification, string>
+
 export const projectCatalog = [
   {
     slug: "amaryllis",
@@ -193,6 +200,18 @@ export const projectCatalog = [
 ] as const satisfies readonly ProjectDefinition[]
 
 export type ProjectSlug = (typeof projectCatalog)[number]["slug"]
+
+export const featuredHomepageProjectSlugs = {
+  solution: ["dubnium", "anthesis", "envuscator"],
+  laboratory: [
+    "anthesis-governance-lab",
+    "dubnium-governed-agent-demo",
+    "myosotis",
+  ],
+} as const satisfies Record<
+  ProjectClassification,
+  readonly ProjectSlug[]
+>
 
 export const projectsByClassification = (
   classification: ProjectClassification,

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,16 +1,46 @@
 import type { MetaFunction } from "@remix-run/node"
 import { Link } from "@remix-run/react"
 import { Card } from "~/components"
-import { cardStyles } from "~/utils/card-styles"
-import { buildCollectionPageStructuredData, buildPageMeta } from "~/utils/seo"
 import {
   AnthesisIcon,
-  BluebellIcon,
-  FortunesIcon,
-  HyperionIcon,
-  MyotosisIcon,
-  AmaryllisIcon,
+  DubniumIcon,
+  MobuildIcon,
+  MyosotisIcon,
 } from "~/components/icons"
+import {
+  featuredHomepageProjectSlugs,
+  projectBySlug,
+  projectCollectionDescriptions,
+} from "~/data/project-catalog"
+import { cardStyles } from "~/utils/card-styles"
+import { buildCollectionPageStructuredData, buildPageMeta } from "~/utils/seo"
+
+const homepageProjectPresentation = {
+  dubnium: {
+    icon: <DubniumIcon />,
+    className: cardStyles.cyan,
+  },
+  anthesis: {
+    icon: <AnthesisIcon />,
+    className: cardStyles.green,
+  },
+  envuscator: {
+    icon: <MobuildIcon />,
+    className: cardStyles.yellow,
+  },
+  "anthesis-governance-lab": {
+    icon: <AnthesisIcon />,
+    className: cardStyles.green,
+  },
+  "dubnium-governed-agent-demo": {
+    icon: <DubniumIcon />,
+    className: cardStyles.cyan,
+  },
+  myosotis: {
+    icon: <MyosotisIcon />,
+    className: cardStyles.blue,
+  },
+} as const
 
 export const meta: MetaFunction = () =>
   buildPageMeta({
@@ -35,14 +65,12 @@ export const handle = {
       },
       {
         name: "Solutions",
-        description:
-          "Products in active use, including Amaryllis, Fortunes Service, and internally used Anthesis.",
+        description: projectCollectionDescriptions.solution,
         url: "https://micrantha.com/solutions",
       },
       {
         name: "Laboratory",
-        description:
-          "Projects in active growth, including Hyperion, Bluebell, and Myotosis.",
+        description: projectCollectionDescriptions.laboratory,
         url: "https://micrantha.com/laboratory",
       },
       {
@@ -317,42 +345,30 @@ export default function Index() {
             Solutions
           </p>
           <h2 className="mt-2 text-2xl tracking-tight md:text-3xl">
-            Products in active use, including internal use.
+            Deployable systems for governed delivery.
           </h2>
           <p className="mt-3 text-base leading-7 text-slate-700">
-            Products that teams can adopt directly, or internally used systems
-            that show the direction of durable delivery.
+            {projectCollectionDescriptions.solution}
           </p>
         </div>
         <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-          <Card
-            title="Amaryllis"
-            url="https://amaryllis.micrantha.com"
-            icon={<AmaryllisIcon />}
-            headingLevel={3}
-            className={cardStyles.neutral}
-          >
-            A React Native SDK for on-device mobile inference.
-          </Card>
-          <Card
-            title="Fortunes Service"
-            url="https://fortunes.micrantha.com"
-            icon={<FortunesIcon />}
-            headingLevel={3}
-            className={cardStyles.yellow}
-          >
-            A microservice and Slack app for UNIX fortunes.
-          </Card>
-          <Card
-            title="Anthesis"
-            url="https://anthesis.dev"
-            icon={<AnthesisIcon />}
-            headingLevel={3}
-            className={cardStyles.green}
-          >
-            Internally used agentic SDLC with governed autonomy and
-            auditability.
-          </Card>
+          {featuredHomepageProjectSlugs.solution.map((slug) => {
+            const project = projectBySlug(slug)
+            const presentation = homepageProjectPresentation[slug]
+
+            return (
+              <Card
+                key={project.slug}
+                title={project.name}
+                url={project.url}
+                icon={presentation.icon}
+                headingLevel={3}
+                className={presentation.className}
+              >
+                {project.summary}
+              </Card>
+            )
+          })}
         </div>
         <Link className="inline-block text-sm" to="/solutions">
           View all solutions
@@ -368,41 +384,30 @@ export default function Index() {
             Laboratory
           </p>
           <h2 className="mt-2 text-2xl tracking-tight md:text-3xl">
-            Projects in active growth.
+            Testbeds that prove the architecture.
           </h2>
           <p className="mt-3 text-base leading-7 text-slate-700">
-            Experimental systems, SDKs, and infrastructure work still being
-            refined in public.
+            {projectCollectionDescriptions.laboratory}
           </p>
         </div>
         <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-          <Card
-            title="Project Hyperion"
-            icon={<HyperionIcon />}
-            url="https://hyperion.micrantha.com"
-            headingLevel={3}
-            className={cardStyles.neutral}
-          >
-            Secure, reproducible lab environments, migrations, and deploys.
-          </Card>
-          <Card
-            title="Bluebell"
-            icon={<BluebellIcon />}
-            url="https://github.com/hackelia-micrantha/bluebell"
-            headingLevel={3}
-            className={cardStyles.blue}
-          >
-            Multiplatform mobile SDK with AI-capable features.
-          </Card>
-          <Card
-            title="Project Myotosis"
-            url="https://myotosis.micrantha.com"
-            icon={<MyotosisIcon />}
-            headingLevel={3}
-            className={cardStyles.green}
-          >
-            MCP and LLM registry for mobile clients.
-          </Card>
+          {featuredHomepageProjectSlugs.laboratory.map((slug) => {
+            const project = projectBySlug(slug)
+            const presentation = homepageProjectPresentation[slug]
+
+            return (
+              <Card
+                key={project.slug}
+                title={project.name}
+                url={project.url}
+                icon={presentation.icon}
+                headingLevel={3}
+                className={presentation.className}
+              >
+                {project.summary}
+              </Card>
+            )
+          })}
         </div>
         <Link className="inline-block text-sm" to="/laboratory">
           Explore the lab

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -384,7 +384,7 @@ export default function Index() {
             Laboratory
           </p>
           <h2 className="mt-2 text-2xl tracking-tight md:text-3xl">
-            Testbeds that prove the architecture.
+            Testbeds that validate the architecture.
           </h2>
           <p className="mt-3 text-base leading-7 text-slate-700">
             {projectCollectionDescriptions.laboratory}

--- a/app/routes/laboratory.tsx
+++ b/app/routes/laboratory.tsx
@@ -13,12 +13,14 @@ import {
   MyosotisIcon,
   ReporaIcon,
 } from "~/components/icons"
-import { projectsByClassification } from "~/data/project-catalog"
+import {
+  projectCollectionDescriptions,
+  projectsByClassification,
+} from "~/data/project-catalog"
 import { cardStyles } from "~/utils/card-styles"
 import { buildCollectionPageStructuredData, buildPageMeta } from "~/utils/seo"
 
-const laboratoryDescription =
-  "Micrantha testbeds and experimental projects that validate contracts, integrations, and emerging engineering capabilities."
+const laboratoryDescription = projectCollectionDescriptions.laboratory
 
 const laboratoryProjects = projectsByClassification("laboratory")
 

--- a/app/routes/solutions.tsx
+++ b/app/routes/solutions.tsx
@@ -9,12 +9,14 @@ import {
   MobuildIcon,
   VeilIcon,
 } from "~/components/icons"
-import { projectsByClassification } from "~/data/project-catalog"
+import {
+  projectCollectionDescriptions,
+  projectsByClassification,
+} from "~/data/project-catalog"
 import { cardStyles } from "~/utils/card-styles"
 import { buildCollectionPageStructuredData, buildPageMeta } from "~/utils/seo"
 
-const solutionsDescription =
-  "Micrantha deployable systems, distributions, tools, and platforms for governed agentic development, mobile engineering, and secure delivery."
+const solutionsDescription = projectCollectionDescriptions.solution
 
 const solutionProjects = projectsByClassification("solution")
 

--- a/e2e/homepage-project-catalog.spec.ts
+++ b/e2e/homepage-project-catalog.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "@playwright/test"
+import {
+  featuredHomepageProjectSlugs,
+  projectBySlug,
+  projectCollectionDescriptions,
+} from "../app/data/project-catalog"
+
+for (const classification of ["solution", "laboratory"] as const) {
+  test(`homepage ${classification} features retain their catalog classification`, () => {
+    for (const slug of featuredHomepageProjectSlugs[classification]) {
+      expect(projectBySlug(slug).classification).toBe(classification)
+    }
+  })
+}
+
+test("homepage project cards resolve identity and copy from the catalog", async ({
+  page,
+}) => {
+  await page.goto("/")
+
+  for (const [classification, sectionId] of [
+    ["solution", "solutions"],
+    ["laboratory", "laboratory"],
+  ] as const) {
+    const section = page.locator(`#${sectionId}`)
+
+    for (const slug of featuredHomepageProjectSlugs[classification]) {
+      const project = projectBySlug(slug)
+      const projectLink = section.locator("a", {
+        has: section.getByRole("heading", {
+          name: project.name,
+          exact: true,
+        }),
+      })
+
+      await expect(projectLink).toHaveAttribute("href", project.url)
+      await expect(section.getByText(project.summary, { exact: true })).toBeVisible()
+    }
+  }
+})
+
+test("homepage JSON-LD uses shared collection taxonomy descriptions", async ({
+  page,
+}) => {
+  await page.goto("/")
+
+  const jsonLdText = await page
+    .locator('script[type="application/ld+json"]')
+    .textContent()
+  const structuredData = JSON.parse(jsonLdText ?? "[]") as Array<{
+    "@type"?: string
+    url?: string
+    mainEntity?: {
+      itemListElement?: Array<{
+        item?: {
+          name?: string
+          description?: string
+        }
+      }>
+    }
+  }>
+  const homepage = structuredData.find(
+    (entry) =>
+      entry["@type"] === "CollectionPage" &&
+      entry.url === "https://micrantha.com/",
+  )
+  const items = homepage?.mainEntity?.itemListElement ?? []
+  const descriptionFor = (name: string) =>
+    items.find((entry) => entry.item?.name === name)?.item?.description
+
+  expect(descriptionFor("Solutions")).toBe(
+    projectCollectionDescriptions.solution,
+  )
+  expect(descriptionFor("Laboratory")).toBe(
+    projectCollectionDescriptions.laboratory,
+  )
+})

--- a/e2e/homepage-project-catalog.spec.ts
+++ b/e2e/homepage-project-catalog.spec.ts
@@ -34,7 +34,9 @@ test("homepage project cards resolve identity and copy from the catalog", async 
       })
 
       await expect(projectLink).toHaveAttribute("href", project.url)
-      await expect(section.getByText(project.summary, { exact: true })).toBeVisible()
+      await expect(
+        section.getByText(project.summary, { exact: true }),
+      ).toBeVisible()
     }
   }
 })


### PR DESCRIPTION
## Summary

- migrate homepage Solution and Laboratory cards to `app/data/project-catalog.ts`
- centralize Solution and Laboratory collection descriptions for reuse by the homepage and collection routes
- feature Dubnium, Anthesis, and Envuscator as homepage Solutions
- feature Anthesis Governance Lab, the Dubnium Governed Agent Demo, and Myosotis as homepage Laboratory projects
- update homepage JSON-LD to use the shared taxonomy descriptions
- add Playwright coverage for featured-project classification, catalog-backed card identity/copy, links, and JSON-LD descriptions

## Why

PR #48 made the project catalog authoritative for the Solutions and Laboratory collection pages, but the homepage still duplicated project names, descriptions, links, and older taxonomy copy. That left a second source of truth and allowed the landing page to drift from the public architecture.

## Design

The catalog now exports:

- shared collection descriptions;
- typed homepage featured-project slug lists;
- the existing project identity and classification data.

The homepage retains only presentation details such as icons and card styles. Names, summaries, links, classification, and featured membership come from the catalog.

## Review fix

- changed “Testbeds that prove the architecture” to “Testbeds that validate the architecture” so the public claim matches the Laboratory’s role as a contract and integration validation surface
- verified that the correction changed exactly one line and introduced no unrelated homepage changes

## Validation

- branch is ahead-only from `main`
- no unresolved review threads, submitted reviews, or PR comments
- tests verify each featured slug belongs to the section classification
- rendered cards are checked against catalog names, summaries, and URLs
- homepage JSON-LD is checked against the shared collection descriptions
- existing non-project homepage sections and layout are preserved
- no GitHub Actions workflow or commit-status checks are registered for the branch
- full local dependency installation and test execution remain unavailable because this environment cannot resolve `github.com`

Closes #49
