### PR TITLE
Document the Cloudflare Pages SSR production contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-4.1-06B6D4?logo=tailwindcss&logoColor=white)](https://tailwindcss.com/)
 [![Playwright](https://img.shields.io/badge/Playwright-E2E-2EAD33?logo=playwright&logoColor=white)](https://playwright.dev/)
-[![Cloudflare Pages](https://img.shields.io/badge/Deploy-Cloudflare_Pages-F38020?logo=cloudflare&logoColor=white)](https://pages.cloudflare.com/)
+[![Cloudflare Pages](https://img.shields.io/badge/Deploy-Cloudflare_Pages-F38020?logo=cloudflare)](https://pages.cloudflare.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-111827.svg)](./LICENSE)
 
 Marketing site and web presence for [micrantha.com](https://micrantha.com), built with Remix, React, TypeScript, and a lean Tailwind CSS pipeline.
@@ -16,7 +16,7 @@ Marketing site and web presence for [micrantha.com](https://micrantha.com), buil
 - Marketing pages for services, solutions, philosophy, support, and laboratory work
 - Shared card palette and icon system for consistent presentation
 - Playwright route, accessibility, and visual regression coverage
-- Cloudflare Pages deployment path with checked-in Wrangler config
+- Cloudflare Pages Functions as the authoritative production runtime
 
 ## Stack
 
@@ -28,7 +28,7 @@ Marketing site and web presence for [micrantha.com](https://micrantha.com), buil
 | Styling | Tailwind CSS 4 via CLI |
 | Quality | ESLint + Prettier |
 | Testing | Playwright |
-| Deployment | Cloudflare Pages |
+| Deployment | Cloudflare Pages Functions |
 
 ## Requirements
 
@@ -50,7 +50,7 @@ Open `http://localhost:3000`.
 | --- | --- |
 | `yarn dev` | Run Remix and Tailwind in watch mode |
 | `yarn build` | Build CSS and Remix for production |
-| `yarn start` | Serve the production build |
+| `yarn start` | Serve the production build locally through `remix-serve` |
 | `yarn lint` | Run ESLint |
 | `yarn lint:fix` | Auto-fix lint issues |
 | `yarn typecheck` | Run the TypeScript build check |
@@ -82,7 +82,8 @@ yarn test:e2e e2e/visual.spec.ts
 Notes:
 
 - Playwright uses `http://127.0.0.1:3000` by default.
-- The test config starts the app automatically with `yarn build && PORT=3000 yarn start`.
+- The current browser suite starts the app with `yarn build && PORT=3000 yarn start`.
+- This validates the production Remix build through `remix-serve`; it does not by itself prove Cloudflare Pages Functions compatibility.
 - Desktop and mobile Chromium projects are configured.
 - The suite includes automated axe accessibility scans for key public routes.
 - On this machine, `/usr/bin/chromium` is used automatically when Playwright-managed browsers are unavailable.
@@ -100,11 +101,14 @@ yarn test:e2e e2e/visual.spec.ts --update-snapshots
 
 ## Deployment
 
-Cloudflare Pages is the primary deployment target.
+Cloudflare Pages Functions is the authoritative production runtime. The request adapter in `functions/[[path]].js` consumes the generated Remix server build, while `public/` supplies static assets and browser output.
+
+See [Cloudflare Pages SSR Architecture](docs/architecture/cloudflare-pages-ssr.md) for the production topology, compatibility boundary, artifact contract, and role of local Node and Docker paths.
 
 Checked-in config:
 
 - `wrangler.toml`
+- `functions/[[path]].js`
 - `package.json` deploy script
 
 Expected environment variables:
@@ -119,7 +123,11 @@ Deploy manually:
 yarn deploy:cloudflare
 ```
 
+The deployment command will be updated under issue #56 to use a repository-pinned Wrangler version and to validate the bundled Pages Function in CI.
+
 ## Docker
+
+The Docker image runs the Remix production build through `remix-serve`. It is useful for local Node portability, but it is not the Cloudflare Pages production artifact or a substitute for the Pages Functions runtime contract.
 
 Build and run locally:
 
@@ -139,10 +147,11 @@ make run
 
 ```text
 app/          Remix routes, components, services, and utilities
+docs/         Architecture and operational decisions
 e2e/          Playwright specs and visual baselines
-public/       Static assets
-build/        Production output after yarn build
-functions/    Edge or platform-specific function code
+public/       Static assets and browser build output
+build/        Remix server build produced by yarn build
+functions/    Cloudflare Pages Functions request adapter
 ```
 
 ## Development Notes

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-4.1-06B6D4?logo=tailwindcss&logoColor=white)](https://tailwindcss.com/)
 [![Playwright](https://img.shields.io/badge/Playwright-E2E-2EAD33?logo=playwright&logoColor=white)](https://playwright.dev/)
-[![Cloudflare Pages](https://img.shields.io/badge/Deploy-Cloudflare_Pages-F38020?logo=cloudflare)](https://pages.cloudflare.com/)
+[![Cloudflare Pages](https://img.shields.io/badge/Deploy-Cloudflare_Pages-F38020?logo=cloudflare&logoColor=white)](https://pages.cloudflare.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-111827.svg)](./LICENSE)
 
 Marketing site and web presence for [micrantha.com](https://micrantha.com), built with Remix, React, TypeScript, and a lean Tailwind CSS pipeline.
@@ -20,15 +20,15 @@ Marketing site and web presence for [micrantha.com](https://micrantha.com), buil
 
 ## Stack
 
-| Area | Tools |
-| --- | --- |
-| App framework | Remix 2 |
-| UI | React 18 |
-| Language | TypeScript |
-| Styling | Tailwind CSS 4 via CLI |
-| Quality | ESLint + Prettier |
-| Testing | Playwright |
-| Deployment | Cloudflare Pages Functions |
+| Area          | Tools                      |
+| ------------- | -------------------------- |
+| App framework | Remix 2                    |
+| UI            | React 18                   |
+| Language      | TypeScript                 |
+| Styling       | Tailwind CSS 4 via CLI     |
+| Quality       | ESLint + Prettier          |
+| Testing       | Playwright                 |
+| Deployment    | Cloudflare Pages Functions |
 
 ## Requirements
 
@@ -46,18 +46,18 @@ Open `http://localhost:3000`.
 
 ## Scripts
 
-| Command | Purpose |
-| --- | --- |
-| `yarn dev` | Run Remix and Tailwind in watch mode |
-| `yarn build` | Build CSS and Remix for production |
-| `yarn start` | Serve the production build locally through `remix-serve` |
-| `yarn lint` | Run ESLint |
-| `yarn lint:fix` | Auto-fix lint issues |
-| `yarn typecheck` | Run the TypeScript build check |
-| `yarn test:e2e` | Run the full Playwright suite |
-| `yarn test:e2e:mobile` | Run the mobile Playwright project only |
-| `yarn test:e2e:headed` | Run Playwright in headed mode |
-| `yarn deploy:cloudflare` | Typecheck, build, and deploy to Cloudflare Pages |
+| Command                  | Purpose                                                  |
+| ------------------------ | -------------------------------------------------------- |
+| `yarn dev`               | Run Remix and Tailwind in watch mode                     |
+| `yarn build`             | Build CSS and Remix for production                       |
+| `yarn start`             | Serve the production build locally through `remix-serve` |
+| `yarn lint`              | Run ESLint                                               |
+| `yarn lint:fix`          | Auto-fix lint issues                                     |
+| `yarn typecheck`         | Run the TypeScript build check                           |
+| `yarn test:e2e`          | Run the full Playwright suite                            |
+| `yarn test:e2e:mobile`   | Run the mobile Playwright project only                   |
+| `yarn test:e2e:headed`   | Run Playwright in headed mode                            |
+| `yarn deploy:cloudflare` | Typecheck, build, and deploy to Cloudflare Pages         |
 
 ## Testing
 

--- a/docs/architecture/cloudflare-pages-ssr.md
+++ b/docs/architecture/cloudflare-pages-ssr.md
@@ -1,0 +1,257 @@
+# Cloudflare Pages SSR Architecture
+
+- **Status:** Accepted baseline
+- **Date:** 2026-08-03
+- **Issue:** #56
+- **Decision scope:** Production runtime, deployment artifacts, compatibility boundaries, and validation responsibilities
+
+## Context
+
+Micrantha Web is a server-rendered Remix 2 application deployed to Cloudflare Pages. The repository also supports local Node serving through `remix-serve`, a Docker image, and Makefile wrappers. Those paths are useful for development and portability, but they do not execute the same adapter or runtime used by production.
+
+The production path is currently defined by:
+
+- `wrangler.toml`, including `pages_build_output_dir`, compatibility date, and `nodejs_compat`;
+- `functions/[[path]].js`, which creates the Remix request handler;
+- `build/index.js`, produced by `remix build`;
+- `public/`, containing static assets and the browser build;
+- Cloudflare Pages Functions, which bundles the root `functions/` directory into a Worker.
+
+Current browser tests start `remix-serve`. That validates the Remix application and production build, but it does not prove that the Pages Function bundles, starts, preserves headers, or behaves correctly under the Workers runtime.
+
+## Decision
+
+Cloudflare Pages Functions is the authoritative production runtime.
+
+The repository must treat the following pipeline as the production contract:
+
+```text
+source
+  -> locked dependency install
+  -> Tailwind CSS build
+  -> Remix browser and server build
+  -> Pages Functions bundle
+  -> public static assets plus Worker artifact
+  -> Cloudflare Pages request
+  -> functions/[[path]].js
+  -> Remix request handler
+  -> streamed response
+```
+
+A change is production-compatible only when it passes the Pages Functions build and runtime contract. Passing through `remix-serve`, the Remix development server, or Docker alone is insufficient.
+
+## Source of truth
+
+### Repository configuration
+
+`wrangler.toml` is the repository source of truth for:
+
+- the Pages project name used by local and scripted operations;
+- the static output directory;
+- the Workers compatibility date;
+- compatibility flags;
+- source-map upload behavior.
+
+Cloudflare dashboard configuration must not silently diverge from the checked-in file. Operational documentation must identify any dashboard-only bindings or secrets and describe how parity is reviewed.
+
+### Production entry point
+
+`functions/[[path]].js` is the production request adapter. It imports the generated Remix server build and translates the Pages Function context into a Remix request.
+
+The adapter must depend only on declared packages and generated deployment artifacts. It must not rely on transitive dependency hoisting, TypeScript source, content source files, or compiler packages at request time.
+
+### Build artifacts
+
+The production deployment consists of:
+
+- `public/` for static assets and browser output;
+- the bundled Pages Function generated from `functions/`;
+- the generated Remix server build consumed by that Function during bundling.
+
+Source `.tsx`, `.md`, and `.mdx` files are build inputs, not runtime dependencies.
+
+## Runtime compatibility boundary
+
+`nodejs_compat` is permitted only for APIs required by the current Remix server build or adapter. New Node-specific runtime dependencies require explicit review.
+
+The application should prefer Web Platform APIs available in both Workers and modern Node runtimes:
+
+- `Request` and `Response`;
+- `Headers`;
+- `URL`;
+- Web Streams;
+- Web Crypto.
+
+Direct filesystem access, child processes, native addons, and assumptions about a writable local filesystem are prohibited in request handling.
+
+The compatibility date is an operational API version. Updating it is a production change and must pass the Pages adapter suite before merge.
+
+## Request and response contract
+
+The Pages runtime must preserve the following externally observable behavior:
+
+### Rendering
+
+- direct requests return meaningful server-rendered HTML;
+- normal browser requests may stream;
+- bot requests may wait for the full stream according to `app/entry.server.tsx`;
+- primary content must not require hydration unless a feature explicitly documents that trade-off.
+
+### Status and routing
+
+- successful routes preserve their intended status;
+- unknown routes return 404;
+- redirects preserve status and `Location`;
+- controlled server failures return the intended error document and status.
+
+### Headers
+
+- document cache policy is preserved through the adapter;
+- CSP nonces in headers and HTML remain paired;
+- security headers apply to successful and error documents;
+- content type and canonical metadata remain correct.
+
+### Assets
+
+- generated Tailwind CSS resolves from `public/`;
+- browser bundles, icons, images, sitemap, and manifest assets resolve through Pages;
+- source maps are uploaded only through the documented deployment path.
+
+## Cache ownership
+
+Application code defines response cache policy. Cloudflare may enforce or transform caching only through documented platform configuration.
+
+The adapter suite must verify representative `Cache-Control` behavior. Future authenticated, preview, draft, or user-specific routes must default to non-shared caching until explicitly classified.
+
+Per-response CSP nonces require the HTML document and CSP header to remain one cache object. Tests must detect header/body recombination or policy loss.
+
+## Environment and analytics
+
+Runtime configuration is resolved through the Pages Function context and request environment. Secrets and bindings are not committed.
+
+The analytics identifier is optional. Missing analytics configuration must not prevent rendering. Adding a new runtime binding requires documentation of:
+
+- its owner;
+- preview and production behavior;
+- failure behavior;
+- security and privacy implications.
+
+## Supported execution paths
+
+### Cloudflare Pages Functions
+
+**Role:** Authoritative production runtime and deployment contract.
+
+Must be exercised by CI through a pinned Wrangler build and local Pages runtime harness.
+
+### `remix-serve`
+
+**Role:** Fast local production-build validation and existing Playwright web server.
+
+It remains useful for application-level browser tests but is not proof of Cloudflare compatibility.
+
+### Remix development server
+
+**Role:** Local development and HMR.
+
+Development-only CSP allowances and WebSocket behavior must not leak into production.
+
+### Docker
+
+**Role:** Local Node portability and optional deployment-parity experiment.
+
+The current image runs `remix-serve`; it is not the Cloudflare production artifact. Docker documentation must state that distinction. If the image is retained as an operational artifact, it requires its own dependency and vulnerability policy.
+
+### Makefile
+
+**Role:** Convenience aliases only.
+
+Package scripts and checked-in platform configuration remain authoritative. Make targets must not define a second deployment contract.
+
+## Toolchain requirements
+
+Wrangler must be declared and lockfile-controlled. Production compatibility checks and deployment scripts must not fetch an unspecified Wrangler version through `npx`.
+
+The Pages Function adapter must use a direct, intentional dependency. The implementation must decide whether to:
+
+1. declare `@remix-run/server-runtime` directly; or
+2. use a public Cloudflare/Remix adapter package that owns the request-handler boundary.
+
+Relying on a transitive package being hoisted is not acceptable.
+
+## CI contract
+
+The required Pages adapter job will:
+
+1. install dependencies with the frozen lockfile;
+2. build CSS and Remix production artifacts;
+3. bundle Pages Functions with the pinned Wrangler version and checked-in configuration;
+4. record Worker bundle metadata and size;
+5. start the bundled application with `wrangler pages dev` or an equivalent Workers-runtime harness;
+6. run HTTP contract tests against that runtime;
+7. fail on unresolved imports, unsupported runtime APIs, missing assets, incorrect statuses, or header regressions.
+
+The baseline suite must cover:
+
+- `/`;
+- one representative nested route;
+- a bot request;
+- a 404;
+- a controlled error route or test fixture;
+- a redirect;
+- CSP nonce/header pairing;
+- cache headers;
+- static CSS and asset resolution;
+- canonical metadata and JSON-LD.
+
+The harness should run from a staged deployment context where practical, proving that source files and build-only packages are unnecessary at request time.
+
+Issue #55 will extend this established harness with MDX-specific and JavaScript-disabled article tests. Those extension tests are not part of the baseline closure criteria for #56.
+
+## Bundle budget
+
+The first implementation slice must record the current compressed and uncompressed Worker size. The enforced limit should preserve explicit headroom below the applicable Cloudflare plan limit.
+
+Subsequent architectural changes must report their delta. Browser route splitting does not guarantee equivalent Worker splitting, so server bundle growth must be measured independently.
+
+## Security considerations
+
+The production adapter is part of the trust boundary. Review must include:
+
+- declared dependency provenance;
+- compatibility flags;
+- environment and binding exposure;
+- CSP nonce preservation;
+- error-path header behavior;
+- source-map handling;
+- accidental inclusion of source content or build-time tooling;
+- cache behavior for any future non-public route.
+
+Detailed CSP and cross-origin policy hardening remains owned by #57, but the baseline adapter tests must prove that current headers survive production execution.
+
+## Consequences
+
+### Positive
+
+- Cloudflare compatibility becomes measurable rather than assumed.
+- MDX and framework migrations gain a stable production acceptance boundary.
+- Runtime-only and build-only dependencies become distinguishable.
+- deployment documentation, scripts, and CI converge on one topology.
+- Worker growth and compatibility-date changes become reviewable.
+
+### Costs
+
+- CI gains another build/runtime path in addition to browser tests.
+- Wrangler becomes a repository-managed dependency.
+- some Node-oriented dependencies may require replacement or explicit compatibility justification.
+- maintaining both Docker and Cloudflare paths requires clear scope to prevent false parity claims.
+
+## Follow-up implementation
+
+1. Pin Wrangler and replace unpinned invocations.
+2. resolve the direct Remix runtime dependency decision;
+3. add Pages Function bundle and runtime scripts;
+4. record the Worker bundle baseline and budget;
+5. add the Cloudflare adapter CI job and HTTP contract suite;
+6. align README, Docker, Makefile, and package script descriptions;
+7. extend the harness from #55, #57, and #58 without redefining the production topology.


### PR DESCRIPTION
## Summary

- add the architecture decision for Cloudflare Pages Functions as the authoritative production runtime
- define build artifacts, runtime compatibility boundaries, cache/header behavior, CI expectations, and bundle budgeting
- classify `remix-serve`, Docker, the development server, and Makefile targets as non-authoritative support paths
- update the README to link the decision and state clearly that existing Playwright tests run through `remix-serve`, not the Pages Functions adapter

## Why

Issue #56 identified a circular dependency with the MDX migration and an undocumented production topology. This PR establishes the baseline architecture independently so later implementation can pin Wrangler, bundle and execute the Pages Function in CI, and extend the harness from #55, #57, and #58.

## Scope

Documentation-only first slice. It intentionally does not yet:

- add or pin Wrangler;
- change the Pages Function adapter;
- add the Cloudflare runtime harness;
- modify the lockfile;
- claim that the adapter contract is already implemented.

## Validation

- reviewed against `wrangler.toml`, `functions/[[path]].js`, `Dockerfile`, `Makefile`, package scripts, and the current CI/browser-test topology
- changed files are Markdown only and will be checked by the required CI workflow

Refs #56