### PR TITLE
Harden global navigation accessibility and reduced motion

### DIFF
--- a/app/components/card.tsx
+++ b/app/components/card.tsx
@@ -54,7 +54,7 @@ export const Card: React.FC<Props> = ({
   const cardClasses =
     "flex w-full flex-col overflow-hidden rounded-2xl border px-6 py-5 shadow-[0_12px_28px_rgba(31,42,42,0.10)] transition-all duration-300"
   const interactiveCardClasses =
-    "cursor-pointer hover:-translate-y-1 hover:shadow-[0_18px_36px_rgba(31,42,42,0.14)]"
+    "interactive-card cursor-pointer hover:-translate-y-1 hover:shadow-[0_18px_36px_rgba(31,42,42,0.14)]"
 
   return (
     <div

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -42,11 +42,14 @@ export const Footer = () => {
           <Link to="/philosophy">Philosophy</Link>
         </div>
 
-        {fortune ? (
-          <div className="max-w-3xl text-sm text-gray-700" aria-live="polite">
-            &#10077; {fortune} &#10078;
-          </div>
-        ) : null}
+        <div className="min-h-12 max-w-3xl text-sm text-gray-700">
+          {fortune ? (
+            <p>
+              <span aria-hidden="true">&#10077;</span> {fortune}{" "}
+              <span aria-hidden="true">&#10078;</span>
+            </p>
+          ) : null}
+        </div>
 
         <div className="text-sm text-gray-600">
           &copy; All Rights Reserved{" "}

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -42,14 +42,12 @@ export const Footer = () => {
           <Link to="/philosophy">Philosophy</Link>
         </div>
 
-        <div className="min-h-12 max-w-3xl text-sm text-gray-700">
-          {fortune ? (
-            <p>
-              <span aria-hidden="true">&#10077;</span> {fortune}{" "}
-              <span aria-hidden="true">&#10078;</span>
-            </p>
-          ) : null}
-        </div>
+        {fortune ? (
+          <div className="max-w-3xl text-sm text-gray-700">
+            <span aria-hidden="true">&#10077;</span> {fortune}{" "}
+            <span aria-hidden="true">&#10078;</span>
+          </div>
+        ) : null}
 
         <div className="text-sm text-gray-600">
           &copy; All Rights Reserved{" "}

--- a/app/components/navigation.tsx
+++ b/app/components/navigation.tsx
@@ -1,6 +1,9 @@
 import { Link, useLocation } from "@remix-run/react"
+import { useEffect, useRef, useState } from "react"
 import { GithubIcon } from "~/components/icons"
 import { ExternalLink } from "./external-link"
+
+const MOBILE_NAVIGATION_ID = "mobile-navigation"
 
 const navLinks = [
   { to: "/services", label: "Services" },
@@ -14,54 +17,93 @@ const navLinks = [
 export const Navigation = () => {
   const location = useLocation()
   const hideMobileLogo = location.pathname === "/"
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
+  const mobileMenuTriggerRef = useRef<HTMLButtonElement>(null)
+  const mobileMenuPanelRef = useRef<HTMLDivElement>(null)
 
   const isActive = (to: string) => {
     if (to === "/") return location.pathname === to
     return location.pathname === to || location.pathname.startsWith(`${to}/`)
   }
 
+  useEffect(() => {
+    setIsMobileMenuOpen(false)
+  }, [location.pathname])
+
+  useEffect(() => {
+    if (!isMobileMenuOpen) return
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target
+      if (!(target instanceof Node)) return
+      if (mobileMenuTriggerRef.current?.contains(target)) return
+      if (mobileMenuPanelRef.current?.contains(target)) return
+
+      setIsMobileMenuOpen(false)
+    }
+
+    document.addEventListener("pointerdown", handlePointerDown)
+    return () => document.removeEventListener("pointerdown", handlePointerDown)
+  }, [isMobileMenuOpen])
+
+  const handleMobileMenuKeyDown = (
+    event: React.KeyboardEvent<HTMLDivElement>,
+  ) => {
+    if (event.key !== "Escape" || !isMobileMenuOpen) return
+
+    event.preventDefault()
+    setIsMobileMenuOpen(false)
+    requestAnimationFrame(() => mobileMenuTriggerRef.current?.focus())
+  }
+
   return (
-    <nav className="relative z-50 border-b border-gray-200 bg-white/90 px-4 py-3 backdrop-blur-sm sm:px-6 lg:px-8">
+    <nav
+      aria-label="Primary"
+      className="relative z-50 border-b border-gray-200 bg-white/90 px-4 py-3 backdrop-blur-sm sm:px-6 lg:px-8"
+    >
       <div className="mx-auto flex w-full max-w-6xl items-center justify-between gap-4">
-        <div className="flex items-center gap-3">
-          <Link
-            to="/"
-            aria-label="Micrantha home"
+        <Link
+          to="/"
+          aria-current={location.pathname === "/" ? "page" : undefined}
+          className="flex items-center gap-3"
+        >
+          <img
+            src="/img/logo.png"
+            width="48"
+            height="48"
+            alt=""
             className={hideMobileLogo ? "hidden sm:block" : "block"}
-          >
-            <img
-              src="/img/logo.png"
-              width="48"
-              height="48"
-              alt="Micrantha logo"
-            />
-          </Link>
-          <Link to="/" className="text-xl font-semibold tracking-tight">
-            Micrantha
-          </Link>
-        </div>
+          />
+          <span className="text-xl font-semibold tracking-tight">Micrantha</span>
+        </Link>
 
         <div className="hidden items-center gap-1 text-sm sm:flex">
-          {navLinks.map((link) => (
-            <Link
-              key={link.to}
-              to={link.to}
-              className={`group relative px-3 py-2 transition-colors ${
-                isActive(link.to)
-                  ? "text-slate-950"
-                  : "text-slate-700 hover:text-slate-950"
-              }`}
-            >
-              {link.label}
-              <span
-                className={`absolute inset-x-3 bottom-1 h-px origin-left bg-slate-900 transition-transform duration-200 ${
-                  isActive(link.to)
-                    ? "scale-x-100"
-                    : "scale-x-0 group-hover:scale-x-100"
+          {navLinks.map((link) => {
+            const active = isActive(link.to)
+
+            return (
+              <Link
+                key={link.to}
+                to={link.to}
+                aria-current={active ? "page" : undefined}
+                className={`group relative px-3 py-2 transition-colors ${
+                  active
+                    ? "text-slate-950"
+                    : "text-slate-700 hover:text-slate-950"
                 }`}
-              />
-            </Link>
-          ))}
+              >
+                {link.label}
+                <span
+                  aria-hidden="true"
+                  className={`absolute inset-x-3 bottom-1 h-px origin-left bg-slate-900 transition-transform duration-200 ${
+                    active
+                      ? "scale-x-100"
+                      : "scale-x-0 group-hover:scale-x-100"
+                  }`}
+                />
+              </Link>
+            )
+          })}
           <ExternalLink
             href="https://github.com/hackelia-micrantha"
             className="ml-1 flex items-center justify-center rounded-lg px-3 py-2 text-slate-700 transition-colors hover:text-slate-950"
@@ -71,31 +113,64 @@ export const Navigation = () => {
           </ExternalLink>
         </div>
 
-        <details className="group relative sm:hidden">
-          <summary className="flex h-11 w-11 list-none items-center justify-center rounded-lg border border-slate-200 text-slate-700 transition-colors hover:bg-slate-50 [&::-webkit-details-marker]:hidden">
-            <span className="sr-only">Toggle menu</span>
-            <span className="flex w-5 flex-col gap-1.5">
-              <span className="h-0.5 rounded bg-current transition-transform group-open:translate-y-2 group-open:rotate-45" />
-              <span className="h-0.5 rounded bg-current transition-opacity group-open:opacity-0" />
-              <span className="h-0.5 rounded bg-current transition-transform group-open:-translate-y-2 group-open:-rotate-45" />
+        <div
+          className="relative sm:hidden"
+          onKeyDown={handleMobileMenuKeyDown}
+        >
+          <button
+            ref={mobileMenuTriggerRef}
+            type="button"
+            aria-controls={MOBILE_NAVIGATION_ID}
+            aria-expanded={isMobileMenuOpen}
+            aria-label={`${isMobileMenuOpen ? "Close" : "Open"} navigation menu`}
+            onClick={() => setIsMobileMenuOpen((open) => !open)}
+            className="flex h-11 w-11 items-center justify-center rounded-lg border border-slate-200 text-slate-700 transition-colors hover:bg-slate-50"
+          >
+            <span aria-hidden="true" className="flex w-5 flex-col gap-1.5">
+              <span
+                className={`h-0.5 rounded bg-current transition-transform ${
+                  isMobileMenuOpen ? "translate-y-2 rotate-45" : ""
+                }`}
+              />
+              <span
+                className={`h-0.5 rounded bg-current transition-opacity ${
+                  isMobileMenuOpen ? "opacity-0" : ""
+                }`}
+              />
+              <span
+                className={`h-0.5 rounded bg-current transition-transform ${
+                  isMobileMenuOpen ? "-translate-y-2 -rotate-45" : ""
+                }`}
+              />
             </span>
-          </summary>
+          </button>
 
-          <div className="mobile-nav-panel absolute right-0 top-full z-[60] mt-3 w-72 origin-top rounded-2xl border border-slate-200 bg-white p-3 shadow-[0_24px_50px_rgba(15,23,42,0.14)]">
+          <div
+            ref={mobileMenuPanelRef}
+            id={MOBILE_NAVIGATION_ID}
+            hidden={!isMobileMenuOpen}
+            className="mobile-nav-panel absolute right-0 top-full z-[60] mt-3 w-72 max-w-[calc(100vw-2rem)] rounded-2xl border border-slate-200 bg-white p-3 shadow-[0_24px_50px_rgba(15,23,42,0.14)]"
+          >
             <div className="flex flex-col gap-1">
-              {navLinks.map((link) => (
-                <Link
-                  key={link.to}
-                  to={link.to}
-                  className={`rounded-xl px-3 py-3 text-sm font-medium transition-colors ${
-                    isActive(link.to)
-                      ? "bg-slate-100 text-slate-950"
-                      : "text-slate-700 hover:bg-slate-50 hover:text-slate-950"
-                  }`}
-                >
-                  {link.label}
-                </Link>
-              ))}
+              {navLinks.map((link) => {
+                const active = isActive(link.to)
+
+                return (
+                  <Link
+                    key={link.to}
+                    to={link.to}
+                    aria-current={active ? "page" : undefined}
+                    onClick={() => setIsMobileMenuOpen(false)}
+                    className={`rounded-xl px-3 py-3 text-sm font-medium transition-colors ${
+                      active
+                        ? "bg-slate-100 text-slate-950"
+                        : "text-slate-700 hover:bg-slate-50 hover:text-slate-950"
+                    }`}
+                  >
+                    {link.label}
+                  </Link>
+                )
+              })}
               <ExternalLink
                 href="https://github.com/hackelia-micrantha"
                 className="rounded-xl px-3 py-3 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50 hover:text-slate-950"
@@ -104,7 +179,7 @@ export const Navigation = () => {
               </ExternalLink>
             </div>
           </div>
-        </details>
+        </div>
       </div>
     </nav>
   )

--- a/app/components/navigation.tsx
+++ b/app/components/navigation.tsx
@@ -74,7 +74,9 @@ export const Navigation = () => {
             alt=""
             className={hideMobileLogo ? "hidden sm:block" : "block"}
           />
-          <span className="text-xl font-semibold tracking-tight">Micrantha</span>
+          <span className="text-xl font-semibold tracking-tight">
+            Micrantha
+          </span>
         </Link>
 
         <div className="hidden items-center gap-1 text-sm sm:flex">
@@ -96,9 +98,7 @@ export const Navigation = () => {
                 <span
                   aria-hidden="true"
                   className={`absolute inset-x-3 bottom-1 h-px origin-left bg-slate-900 transition-transform duration-200 ${
-                    active
-                      ? "scale-x-100"
-                      : "scale-x-0 group-hover:scale-x-100"
+                    active ? "scale-x-100" : "scale-x-0 group-hover:scale-x-100"
                   }`}
                 />
               </Link>
@@ -113,10 +113,7 @@ export const Navigation = () => {
           </ExternalLink>
         </div>
 
-        <div
-          className="relative sm:hidden"
-          onKeyDown={handleMobileMenuKeyDown}
-        >
+        <div className="relative sm:hidden" onKeyDown={handleMobileMenuKeyDown}>
           <button
             ref={mobileMenuTriggerRef}
             type="button"

--- a/app/components/navigation.tsx
+++ b/app/components/navigation.tsx
@@ -1,5 +1,4 @@
 import { Link, useLocation } from "@remix-run/react"
-import { useEffect, useRef, useState } from "react"
 import { GithubIcon } from "~/components/icons"
 import { ExternalLink } from "./external-link"
 
@@ -17,47 +16,10 @@ const navLinks = [
 export const Navigation = () => {
   const location = useLocation()
   const hideMobileLogo = location.pathname === "/"
-  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
-  const mobileMenuTriggerRef = useRef<HTMLButtonElement>(null)
-  const mobileMenuPanelRef = useRef<HTMLDivElement>(null)
-  const previousPathnameRef = useRef(location.pathname)
 
   const isActive = (to: string) => {
     if (to === "/") return location.pathname === to
     return location.pathname === to || location.pathname.startsWith(`${to}/`)
-  }
-
-  useEffect(() => {
-    if (previousPathnameRef.current === location.pathname) return
-
-    previousPathnameRef.current = location.pathname
-    setIsMobileMenuOpen(false)
-  }, [location.pathname])
-
-  useEffect(() => {
-    if (!isMobileMenuOpen) return
-
-    const handlePointerDown = (event: PointerEvent) => {
-      const target = event.target
-      if (!(target instanceof Node)) return
-      if (mobileMenuTriggerRef.current?.contains(target)) return
-      if (mobileMenuPanelRef.current?.contains(target)) return
-
-      setIsMobileMenuOpen(false)
-    }
-
-    document.addEventListener("pointerdown", handlePointerDown)
-    return () => document.removeEventListener("pointerdown", handlePointerDown)
-  }, [isMobileMenuOpen])
-
-  const handleMobileMenuKeyDown = (
-    event: React.KeyboardEvent<HTMLDivElement>,
-  ) => {
-    if (event.key !== "Escape" || !isMobileMenuOpen) return
-
-    event.preventDefault()
-    setIsMobileMenuOpen(false)
-    requestAnimationFrame(() => mobileMenuTriggerRef.current?.focus())
   }
 
   return (
@@ -117,39 +79,24 @@ export const Navigation = () => {
           </ExternalLink>
         </div>
 
-        <div className="relative sm:hidden" onKeyDown={handleMobileMenuKeyDown}>
-          <button
-            ref={mobileMenuTriggerRef}
-            type="button"
+        <details
+          data-mobile-navigation
+          className="group relative sm:hidden"
+        >
+          <summary
             aria-controls={MOBILE_NAVIGATION_ID}
-            aria-expanded={isMobileMenuOpen}
-            aria-label={`${isMobileMenuOpen ? "Close" : "Open"} navigation menu`}
-            onClick={() => setIsMobileMenuOpen((open) => !open)}
-            className="flex h-11 w-11 items-center justify-center rounded-lg border border-slate-200 text-slate-700 transition-colors hover:bg-slate-50"
+            className="flex h-11 w-11 list-none items-center justify-center rounded-lg border border-slate-200 text-slate-700 transition-colors hover:bg-slate-50 [&::-webkit-details-marker]:hidden"
           >
+            <span className="sr-only">Navigation menu</span>
             <span aria-hidden="true" className="flex w-5 flex-col gap-1.5">
-              <span
-                className={`h-0.5 rounded bg-current transition-transform ${
-                  isMobileMenuOpen ? "translate-y-2 rotate-45" : ""
-                }`}
-              />
-              <span
-                className={`h-0.5 rounded bg-current transition-opacity ${
-                  isMobileMenuOpen ? "opacity-0" : ""
-                }`}
-              />
-              <span
-                className={`h-0.5 rounded bg-current transition-transform ${
-                  isMobileMenuOpen ? "-translate-y-2 -rotate-45" : ""
-                }`}
-              />
+              <span className="h-0.5 rounded bg-current transition-transform group-open:translate-y-2 group-open:rotate-45" />
+              <span className="h-0.5 rounded bg-current transition-opacity group-open:opacity-0" />
+              <span className="h-0.5 rounded bg-current transition-transform group-open:-translate-y-2 group-open:-rotate-45" />
             </span>
-          </button>
+          </summary>
 
           <div
-            ref={mobileMenuPanelRef}
             id={MOBILE_NAVIGATION_ID}
-            hidden={!isMobileMenuOpen}
             className="mobile-nav-panel absolute right-0 top-full z-[60] mt-3 w-72 max-w-[calc(100vw-2rem)] rounded-2xl border border-slate-200 bg-white p-3 shadow-[0_24px_50px_rgba(15,23,42,0.14)]"
           >
             <div className="flex flex-col gap-1">
@@ -161,7 +108,6 @@ export const Navigation = () => {
                     key={link.to}
                     to={link.to}
                     aria-current={active ? "page" : undefined}
-                    onClick={() => setIsMobileMenuOpen(false)}
                     className={`rounded-xl px-3 py-3 text-sm font-medium transition-colors ${
                       active
                         ? "bg-slate-100 text-slate-950"
@@ -180,7 +126,7 @@ export const Navigation = () => {
               </ExternalLink>
             </div>
           </div>
-        </div>
+        </details>
       </div>
     </nav>
   )

--- a/app/components/navigation.tsx
+++ b/app/components/navigation.tsx
@@ -79,10 +79,7 @@ export const Navigation = () => {
           </ExternalLink>
         </div>
 
-        <details
-          data-mobile-navigation
-          className="group relative sm:hidden"
-        >
+        <details data-mobile-navigation className="group relative sm:hidden">
           <summary
             aria-controls={MOBILE_NAVIGATION_ID}
             className="flex h-11 w-11 list-none items-center justify-center rounded-lg border border-slate-200 text-slate-700 transition-colors hover:bg-slate-50 [&::-webkit-details-marker]:hidden"

--- a/app/components/navigation.tsx
+++ b/app/components/navigation.tsx
@@ -20,6 +20,7 @@ export const Navigation = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
   const mobileMenuTriggerRef = useRef<HTMLButtonElement>(null)
   const mobileMenuPanelRef = useRef<HTMLDivElement>(null)
+  const previousPathnameRef = useRef(location.pathname)
 
   const isActive = (to: string) => {
     if (to === "/") return location.pathname === to
@@ -27,6 +28,9 @@ export const Navigation = () => {
   }
 
   useEffect(() => {
+    if (previousPathnameRef.current === location.pathname) return
+
+    previousPathnameRef.current = location.pathname
     setIsMobileMenuOpen(false)
   }, [location.pathname])
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -184,6 +184,7 @@ export default function App() {
           <Outlet />
         </main>
         <Footer />
+        <script nonce={state?.nonce} src="/navigation.js" defer />
         <ScrollRestoration nonce={state?.nonce} />
         <Scripts nonce={state?.nonce} />
         <Analytics id={state?.analyticsId} nonce={state?.nonce} />

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -50,6 +50,7 @@ function buildContentSecurityPolicy(nonce: string, isDev: boolean) {
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: "/tailwind.css" },
+  { rel: "stylesheet", href: "/accessibility.css" },
   { rel: "shortcut icon", href: "/icon/favicon.ico" },
   { rel: "manifest", href: "/icon/site.webmanifest" },
   {
@@ -177,6 +178,7 @@ export default function App() {
         <Navigation />
         <main
           id="content"
+          tabIndex={-1}
           className="body mx-auto w-full max-w-6xl px-4 py-8 sm:px-6 lg:px-8"
         >
           <Outlet />

--- a/e2e/accessibility-shell.spec.ts
+++ b/e2e/accessibility-shell.spec.ts
@@ -114,6 +114,43 @@ test("mobile menu remains inside a 320px viewport", async ({
   expect(hasDocumentOverflow).toBe(false)
 })
 
+test("mobile navigation remains usable without JavaScript", async ({
+  browser,
+}, testInfo) => {
+  test.skip(
+    testInfo.project.name !== "desktop-chromium",
+    "The no-JavaScript contract only needs one browser-project assertion.",
+  )
+
+  const context = await browser.newContext({
+    javaScriptEnabled: false,
+    viewport: { width: 390, height: 844 },
+  })
+
+  try {
+    const page = await context.newPage()
+    await page.goto("/")
+
+    const navigation = page.getByRole("navigation", { name: "Primary" })
+    const disclosure = navigation.locator("details[data-mobile-navigation]")
+    const trigger = disclosure.locator("summary")
+
+    await expect(trigger).toHaveAccessibleName("Navigation menu")
+    await trigger.click()
+    await expect(disclosure).toHaveAttribute("open", "")
+
+    const solutionsLink = navigation.getByRole("link", {
+      name: "Solutions",
+      exact: true,
+    })
+    await expect(solutionsLink).toBeVisible()
+    await solutionsLink.click()
+    await expect(page).toHaveURL(/\/solutions$/)
+  } finally {
+    await context.close()
+  }
+})
+
 test("reduced-motion preference suppresses decorative movement", async ({
   page,
 }, testInfo) => {

--- a/e2e/accessibility-shell.spec.ts
+++ b/e2e/accessibility-shell.spec.ts
@@ -11,10 +11,9 @@ test("skip link moves focus to the main content", async ({ page }) => {
   await expect(page.locator("main#content")).toBeFocused()
 })
 
-test("desktop navigation exposes the current route", async (
-  { page },
-  testInfo,
-) => {
+test("desktop navigation exposes the current route", async ({
+  page,
+}, testInfo) => {
   test.skip(
     testInfo.project.name !== "desktop-chromium",
     "Desktop navigation is visible only in the desktop project.",
@@ -31,10 +30,9 @@ test("desktop navigation exposes the current route", async (
   ).not.toHaveAttribute("aria-current", "page")
 })
 
-test("mobile navigation supports keyboard dismissal and route changes", async (
-  { page },
-  testInfo,
-) => {
+test("mobile navigation supports keyboard dismissal and route changes", async ({
+  page,
+}, testInfo) => {
   test.skip(
     testInfo.project.name !== "mobile-chromium",
     "Mobile disclosure behavior is exercised in the mobile project.",
@@ -72,10 +70,9 @@ test("mobile navigation supports keyboard dismissal and route changes", async (
   ).toHaveAttribute("aria-current", "page")
 })
 
-test("mobile menu remains inside a 320px viewport", async (
-  { page },
-  testInfo,
-) => {
+test("mobile menu remains inside a 320px viewport", async ({
+  page,
+}, testInfo) => {
   test.skip(
     testInfo.project.name !== "mobile-chromium",
     "Narrow mobile behavior is exercised in the mobile project.",
@@ -85,9 +82,7 @@ test("mobile menu remains inside a 320px viewport", async (
   await page.goto("/")
 
   const navigation = page.getByRole("navigation", { name: "Primary" })
-  await navigation
-    .getByRole("button", { name: /navigation menu/i })
-    .click()
+  await navigation.getByRole("button", { name: /navigation menu/i }).click()
 
   const panel = page.locator("#mobile-navigation")
   await expect(panel).toBeVisible()
@@ -98,15 +93,16 @@ test("mobile menu remains inside a 320px viewport", async (
   expect((bounds?.x ?? 0) + (bounds?.width ?? 0)).toBeLessThanOrEqual(320)
 
   const hasDocumentOverflow = await page.evaluate(
-    () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+    () =>
+      document.documentElement.scrollWidth >
+      document.documentElement.clientWidth,
   )
   expect(hasDocumentOverflow).toBe(false)
 })
 
-test("reduced-motion preference suppresses decorative movement", async (
-  { page },
-  testInfo,
-) => {
+test("reduced-motion preference suppresses decorative movement", async ({
+  page,
+}, testInfo) => {
   test.skip(
     testInfo.project.name !== "desktop-chromium",
     "Reduced-motion styling only needs one browser-project assertion.",
@@ -119,8 +115,8 @@ test("reduced-motion preference suppresses decorative movement", async (
     .getByRole("link", { name: "Request a consultation" })
     .first()
   const maxTransitionDurationMs = await primaryButton.evaluate((element) => {
-    const durations = getComputedStyle(element).transitionDuration
-      .split(",")
+    const durations = getComputedStyle(element)
+      .transitionDuration.split(",")
       .map((value) => value.trim())
       .map((value) =>
         value.endsWith("ms")

--- a/e2e/accessibility-shell.spec.ts
+++ b/e2e/accessibility-shell.spec.ts
@@ -40,13 +40,14 @@ test("mobile navigation supports keyboard dismissal and route changes", async ({
 
   await page.goto("/")
   const navigation = page.getByRole("navigation", { name: "Primary" })
-  const trigger = navigation.getByRole("button", {
-    name: /navigation menu/i,
-  })
+  const disclosure = navigation.locator("details[data-mobile-navigation]")
+  const trigger = disclosure.locator("summary")
 
+  await expect(trigger).toHaveAccessibleName("Navigation menu")
   await expect(trigger).toHaveAttribute("aria-expanded", "false")
   await trigger.focus()
   await page.keyboard.press("Enter")
+  await expect(disclosure).toHaveAttribute("open", "")
   await expect(trigger).toHaveAttribute("aria-expanded", "true")
 
   const solutionsLink = navigation.getByRole("link", {
@@ -56,17 +57,28 @@ test("mobile navigation supports keyboard dismissal and route changes", async ({
   await expect(solutionsLink).toBeVisible()
   await solutionsLink.focus()
   await page.keyboard.press("Escape")
+  await expect(disclosure).not.toHaveAttribute("open", "")
   await expect(trigger).toHaveAttribute("aria-expanded", "false")
   await expect(trigger).toBeFocused()
 
   await trigger.click()
   await solutionsLink.click()
   await expect(page).toHaveURL(/\/solutions$/)
-  await expect(trigger).toHaveAttribute("aria-expanded", "false")
 
-  await trigger.click()
+  const updatedNavigation = page.getByRole("navigation", { name: "Primary" })
+  const updatedDisclosure = updatedNavigation.locator(
+    "details[data-mobile-navigation]",
+  )
+  const updatedTrigger = updatedDisclosure.locator("summary")
+
+  await expect(updatedDisclosure).not.toHaveAttribute("open", "")
+  await expect(updatedTrigger).toHaveAttribute("aria-expanded", "false")
+  await updatedTrigger.click()
   await expect(
-    navigation.getByRole("link", { name: "Solutions", exact: true }),
+    updatedNavigation.getByRole("link", {
+      name: "Solutions",
+      exact: true,
+    }),
   ).toHaveAttribute("aria-current", "page")
 })
 
@@ -82,9 +94,11 @@ test("mobile menu remains inside a 320px viewport", async ({
   await page.goto("/")
 
   const navigation = page.getByRole("navigation", { name: "Primary" })
-  await navigation.getByRole("button", { name: /navigation menu/i }).click()
+  const disclosure = navigation.locator("details[data-mobile-navigation]")
+  await disclosure.locator("summary").click()
 
   const panel = page.locator("#mobile-navigation")
+  await expect(disclosure).toHaveAttribute("open", "")
   await expect(panel).toBeVisible()
   const bounds = await panel.boundingBox()
 

--- a/e2e/accessibility-shell.spec.ts
+++ b/e2e/accessibility-shell.spec.ts
@@ -1,0 +1,141 @@
+import { expect, test } from "@playwright/test"
+
+test("skip link moves focus to the main content", async ({ page }) => {
+  await page.goto("/")
+
+  await page.keyboard.press("Tab")
+  const skipLink = page.getByRole("link", { name: "Skip to content" })
+  await expect(skipLink).toBeFocused()
+
+  await page.keyboard.press("Enter")
+  await expect(page.locator("main#content")).toBeFocused()
+})
+
+test("desktop navigation exposes the current route", async (
+  { page },
+  testInfo,
+) => {
+  test.skip(
+    testInfo.project.name !== "desktop-chromium",
+    "Desktop navigation is visible only in the desktop project.",
+  )
+
+  await page.goto("/solutions")
+  const navigation = page.getByRole("navigation", { name: "Primary" })
+
+  await expect(
+    navigation.getByRole("link", { name: "Solutions", exact: true }),
+  ).toHaveAttribute("aria-current", "page")
+  await expect(
+    navigation.getByRole("link", { name: "Services", exact: true }),
+  ).not.toHaveAttribute("aria-current", "page")
+})
+
+test("mobile navigation supports keyboard dismissal and route changes", async (
+  { page },
+  testInfo,
+) => {
+  test.skip(
+    testInfo.project.name !== "mobile-chromium",
+    "Mobile disclosure behavior is exercised in the mobile project.",
+  )
+
+  await page.goto("/")
+  const navigation = page.getByRole("navigation", { name: "Primary" })
+  const trigger = navigation.getByRole("button", {
+    name: /navigation menu/i,
+  })
+
+  await expect(trigger).toHaveAttribute("aria-expanded", "false")
+  await trigger.focus()
+  await page.keyboard.press("Enter")
+  await expect(trigger).toHaveAttribute("aria-expanded", "true")
+
+  const solutionsLink = navigation.getByRole("link", {
+    name: "Solutions",
+    exact: true,
+  })
+  await expect(solutionsLink).toBeVisible()
+  await solutionsLink.focus()
+  await page.keyboard.press("Escape")
+  await expect(trigger).toHaveAttribute("aria-expanded", "false")
+  await expect(trigger).toBeFocused()
+
+  await trigger.click()
+  await solutionsLink.click()
+  await expect(page).toHaveURL(/\/solutions$/)
+  await expect(trigger).toHaveAttribute("aria-expanded", "false")
+
+  await trigger.click()
+  await expect(
+    navigation.getByRole("link", { name: "Solutions", exact: true }),
+  ).toHaveAttribute("aria-current", "page")
+})
+
+test("mobile menu remains inside a 320px viewport", async (
+  { page },
+  testInfo,
+) => {
+  test.skip(
+    testInfo.project.name !== "mobile-chromium",
+    "Narrow mobile behavior is exercised in the mobile project.",
+  )
+
+  await page.setViewportSize({ width: 320, height: 800 })
+  await page.goto("/")
+
+  const navigation = page.getByRole("navigation", { name: "Primary" })
+  await navigation
+    .getByRole("button", { name: /navigation menu/i })
+    .click()
+
+  const panel = page.locator("#mobile-navigation")
+  await expect(panel).toBeVisible()
+  const bounds = await panel.boundingBox()
+
+  expect(bounds).not.toBeNull()
+  expect(bounds?.x ?? -1).toBeGreaterThanOrEqual(0)
+  expect((bounds?.x ?? 0) + (bounds?.width ?? 0)).toBeLessThanOrEqual(320)
+
+  const hasDocumentOverflow = await page.evaluate(
+    () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+  )
+  expect(hasDocumentOverflow).toBe(false)
+})
+
+test("reduced-motion preference suppresses decorative movement", async (
+  { page },
+  testInfo,
+) => {
+  test.skip(
+    testInfo.project.name !== "desktop-chromium",
+    "Reduced-motion styling only needs one browser-project assertion.",
+  )
+
+  await page.emulateMedia({ reducedMotion: "reduce" })
+  await page.goto("/")
+
+  const primaryButton = page
+    .getByRole("link", { name: "Request a consultation" })
+    .first()
+  const maxTransitionDurationMs = await primaryButton.evaluate((element) => {
+    const durations = getComputedStyle(element).transitionDuration
+      .split(",")
+      .map((value) => value.trim())
+      .map((value) =>
+        value.endsWith("ms")
+          ? Number.parseFloat(value)
+          : Number.parseFloat(value) * 1000,
+      )
+
+    return Math.max(...durations)
+  })
+
+  expect(maxTransitionDurationMs).toBeLessThanOrEqual(1)
+  await primaryButton.hover()
+  await expect(primaryButton).toHaveCSS("transform", "none")
+
+  const interactiveCard = page.locator(".interactive-card").first()
+  await interactiveCard.hover()
+  await expect(interactiveCard).toHaveCSS("transform", "none")
+})

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -12,9 +12,7 @@ async function clickNavigationLink(page: Page, name: keyof typeof navTargets) {
   const visibleLink = navigation.locator(`a[href="${target}"]:visible`)
 
   if ((await visibleLink.count()) === 0) {
-    await navigation
-      .getByRole("button", { name: /navigation menu/i })
-      .click()
+    await navigation.getByRole("button", { name: /navigation menu/i }).click()
   }
 
   await visibleLink.click()

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -12,7 +12,7 @@ async function clickNavigationLink(page: Page, name: keyof typeof navTargets) {
   const visibleLink = navigation.locator(`a[href="${target}"]:visible`)
 
   if ((await visibleLink.count()) === 0) {
-    await navigation.getByRole("button", { name: "Navigation menu" }).click()
+    await navigation.locator("details[data-mobile-navigation] summary").click()
   }
 
   await visibleLink.click()

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -7,12 +7,14 @@ const navTargets = {
 }
 
 async function clickNavigationLink(page: Page, name: keyof typeof navTargets) {
-  const navigation = page.getByRole("navigation")
+  const navigation = page.getByRole("navigation", { name: "Primary" })
   const target = navTargets[name]
   const visibleLink = navigation.locator(`a[href="${target}"]:visible`)
 
   if ((await visibleLink.count()) === 0) {
-    await navigation.locator("summary:visible").click()
+    await navigation
+      .getByRole("button", { name: /navigation menu/i })
+      .click()
   }
 
   await visibleLink.click()

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -12,7 +12,7 @@ async function clickNavigationLink(page: Page, name: keyof typeof navTargets) {
   const visibleLink = navigation.locator(`a[href="${target}"]:visible`)
 
   if ((await visibleLink.count()) === 0) {
-    await navigation.getByRole("button", { name: /navigation menu/i }).click()
+    await navigation.getByRole("button", { name: "Navigation menu" }).click()
   }
 
   await visibleLink.click()

--- a/public/accessibility.css
+++ b/public/accessibility.css
@@ -1,0 +1,27 @@
+@media (prefers-reduced-motion: reduce) {
+  html:focus-within {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-delay: 0s !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-delay: 0s !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  .button:hover,
+  .interactive-card:hover {
+    transform: none;
+  }
+}
+
+.mobile-nav-panel {
+  opacity: 1;
+  pointer-events: auto;
+  transform: none;
+}

--- a/public/accessibility.css
+++ b/public/accessibility.css
@@ -19,9 +19,3 @@
     transform: none;
   }
 }
-
-.mobile-nav-panel {
-  opacity: 1;
-  pointer-events: auto;
-  transform: none;
-}

--- a/public/navigation.js
+++ b/public/navigation.js
@@ -1,6 +1,4 @@
-const mobileNavigations = document.querySelectorAll(
-  "[data-mobile-navigation]",
-)
+const mobileNavigations = document.querySelectorAll("[data-mobile-navigation]")
 
 for (const navigation of mobileNavigations) {
   if (!(navigation instanceof HTMLDetailsElement)) continue

--- a/public/navigation.js
+++ b/public/navigation.js
@@ -1,0 +1,63 @@
+const mobileNavigations = document.querySelectorAll(
+  "[data-mobile-navigation]",
+)
+
+for (const navigation of mobileNavigations) {
+  if (!(navigation instanceof HTMLDetailsElement)) continue
+
+  const trigger = navigation.querySelector("summary")
+  const panelId = trigger?.getAttribute("aria-controls")
+  const panel = panelId ? document.getElementById(panelId) : null
+
+  if (!(trigger instanceof HTMLElement) || !(panel instanceof HTMLElement)) {
+    continue
+  }
+
+  const syncExpandedState = () => {
+    trigger.setAttribute("aria-expanded", String(navigation.open))
+  }
+
+  const closeNavigation = (restoreFocus = false) => {
+    navigation.open = false
+    syncExpandedState()
+
+    if (restoreFocus) {
+      trigger.focus()
+    }
+  }
+
+  navigation.addEventListener("toggle", syncExpandedState)
+
+  navigation.addEventListener("keydown", (event) => {
+    if (event.key !== "Escape" || !navigation.open) return
+
+    event.preventDefault()
+    closeNavigation(true)
+  })
+
+  panel.addEventListener("click", (event) => {
+    const target = event.target
+
+    if (target instanceof Element && target.closest("a")) {
+      closeNavigation()
+    }
+  })
+
+  document.addEventListener("pointerdown", (event) => {
+    const target = event.target
+
+    if (
+      navigation.open &&
+      target instanceof Node &&
+      !navigation.contains(target)
+    ) {
+      closeNavigation()
+    }
+  })
+
+  window.addEventListener("pageshow", () => {
+    closeNavigation()
+  })
+
+  syncExpandedState()
+}


### PR DESCRIPTION
## Summary

- preserve native `<details>/<summary>` mobile navigation so the primary menu works before JavaScript and while React hydration remains intentionally disabled
- add a small CSP-compatible enhancement for explicit expanded-state synchronization, Escape dismissal, focus return, outside dismissal, and close-on-link activation
- expose active routes with `aria-current="page"` and combine duplicate adjacent home links
- keep the panel within narrow viewports and make the skip-link target programmatically focusable
- remove live-region semantics from the decorative footer fortune without leaving empty layout space when the client runtime is unavailable
- add a global reduced-motion safeguard and suppress button/card lift under reduced-motion preferences
- add focused Playwright contracts for skip links, active routes, native mobile keyboard behavior, 320px reflow, reduced motion, and mobile navigation with JavaScript disabled

## Why

The global application shell had a sound semantic baseline, but active navigation state was visual only, decorative asynchronous footer content was announced to assistive technology, and motion preferences were not explicitly respected.

The first implementation attempted a controlled React disclosure. CI correctly exposed that this was incompatible with the repository's deliberate `ENABLE_HYDRATION = false` production hardening. This PR now keeps primary navigation progressively enhanced: native HTML owns baseline disclosure behavior, while a small static enhancement adds the interaction contracts native HTML does not provide consistently.

## Scope and issue boundaries

Closes #61.

This PR implements the immediate shell behavior and focused regression tests. Broader route-template accessibility and responsive coverage remains in #68. Screenshot baseline and visual-regression workflow ownership remains in #53. Restoring full React hydration is owned by #76.

The 320 CSS-pixel contract also exercises the effective reflow width of a 640-pixel layout at 200% zoom. Broader 400% zoom, large-text, and route-template expansion coverage remains in #68.

## Validation

Successful merge-ref workflow: `30861164758`.

### Quality — passed

- full-repository formatting;
- full-repository lint;
- TypeScript project check;
- production build;
- pinned Wrangler verification;
- Cloudflare Pages Function bundle;
- bundle metadata reporting;
- Cloudflare Pages adapter contract.

### End-to-end — passed

- complete functional desktop/mobile Chromium suite;
- skip-link focus transfer;
- current-route semantics;
- mobile keyboard disclosure and Escape/focus return;
- close-on-navigation behavior;
- 320px viewport/reflow without document overflow;
- reduced-motion behavior;
- native mobile navigation with JavaScript disabled;
- existing axe and route contracts.

No failure artifact was produced.