### PR TITLE
Complete the Cloudflare Pages production contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,11 @@ jobs:
       - name: Bundle Cloudflare Pages Function
         run: yarn cloudflare:functions:build
 
+      - name: Enforce Cloudflare Worker size budget
+        env:
+          CLOUDFLARE_WORKERS_PLAN: ${{ vars.CLOUDFLARE_WORKERS_PLAN || 'free' }}
+        run: yarn test:cloudflare:size
+
       - name: Report Pages Function bundle files
         run: find .cloudflare/functions -type f -printf '%p %s bytes\n' | sort
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![React](https://img.shields.io/badge/React-18.3-149ECA?logo=react&logoColor=white)](https://react.dev/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-4.1-06B6D4?logo=tailwindcss&logoColor=white)](https://tailwindcss.com/)
-[![Playwright](https://img.shields.io/badge/Playwright-E2E-2EAD33?logo=playwright&logoColor=white)](https://playwright.dev/)
+[![Playwright](https://img.shields.io/badge/Playwright-E2E-2EAD33?logo=playwright)](https://playwright.dev/)
 [![Cloudflare Pages](https://img.shields.io/badge/Deploy-Cloudflare_Pages-F38020?logo=cloudflare&logoColor=white)](https://pages.cloudflare.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-111827.svg)](./LICENSE)
 
@@ -51,11 +51,12 @@ Open `http://localhost:3000`.
 | `yarn dev`                        | Run Remix and Tailwind in watch mode                           |
 | `yarn build`                      | Build CSS and Remix for production                             |
 | `yarn cloudflare:functions:build` | Bundle the Pages Function with pinned Wrangler                 |
-| `yarn cloudflare:runtime:stage`   | Stage only the deployable Pages assets and prebuilt Worker     |
+| `yarn cloudflare:runtime:stage`   | Stage only the deployable Pages assets and generated Worker    |
 | `yarn start`                      | Serve the production build locally through `remix-serve`       |
 | `yarn lint`                       | Run ESLint                                                     |
 | `yarn lint:fix`                   | Auto-fix lint issues                                           |
 | `yarn typecheck`                  | Run the TypeScript build check                                 |
+| `yarn test:cloudflare:size`       | Enforce compressed and raw Worker bundle budgets               |
 | `yarn test:cloudflare:adapter`    | Exercise the built Pages Function entry directly               |
 | `yarn test:cloudflare:runtime`    | Exercise the staged Worker through the local Pages runtime     |
 | `yarn test:e2e`                   | Run the full Playwright suite                                  |
@@ -84,15 +85,24 @@ yarn build
 yarn test:cloudflare:adapter
 ```
 
-This imports the checked-in Pages Function entry against the generated Remix server build and verifies representative SSR, binding, status, CSP nonce, cache, and security-header behavior. It is a fast adapter-level diagnostic, not a Workers-runtime substitute.
+This imports the checked-in Pages Function entry against the generated Remix server build and verifies representative SSR, binding, status, redirect, method-error, CSP nonce, cache, and security-header behavior. It is a fast adapter-level diagnostic, not a Workers-runtime substitute.
 
-Bundle the Pages Function using the repository-pinned Wrangler version, then run the authoritative local runtime contract:
+Bundle the Pages Function using the repository-pinned Wrangler version, enforce its bundle budget, and run the authoritative local runtime contract:
 
 ```sh
 yarn build
 yarn cloudflare:functions:build
+yarn test:cloudflare:size
 yarn test:cloudflare:runtime
 ```
+
+The size gate defaults to the Cloudflare Workers Free-plan compressed limit and reserves 20% internal headroom. It also enforces 20% headroom below the platform's uncompressed limit. Set `CLOUDFLARE_WORKERS_PLAN=paid` only when the deployed Pages project uses a paid Workers plan:
+
+```sh
+CLOUDFLARE_WORKERS_PLAN=paid yarn test:cloudflare:size
+```
+
+The report is written to `.cloudflare/functions/size-report.json` and retained with the CI bundle artifact.
 
 The runtime test creates an ignored `.cloudflare/runtime/` stage containing only:
 
@@ -101,9 +111,9 @@ The runtime test creates an ignored `.cloudflare/runtime/` stage containing only
 - generated Worker route and build metadata;
 - `wrangler.toml`.
 
-It deliberately excludes `app/`, `build/`, `functions/`, and `node_modules/` from the staged runtime payload. Wrangler consumes that source-free stage through Pages advanced mode, performs the final compatibility-aware bundle required by the Worker’s `nodejs_compat` imports, and starts workerd with `pages dev public`. The contract then verifies SSR, nested and bot routes, 404 behavior, CSP nonce pairing, cache and security headers, static CSS, and a generated browser bundle.
+It deliberately excludes `app/`, `build/`, `functions/`, and `node_modules/` from the staged runtime payload. Wrangler consumes that source-free stage through Pages advanced mode, performs the final compatibility-aware bundle required by the Worker's `nodejs_compat` imports, and starts workerd with `pages dev public`. The contract verifies SSR, nested and bot routes, the legacy `/contact` redirect, 404 and 405 responses, CSP nonce pairing, cache and security headers, static CSS, and a generated browser bundle.
 
-The generated function bundle, config, build metadata, and runtime manifest are written under the ignored `.cloudflare/` directory. Required CI uploads those outputs for inspection. Issue #56 retains the remaining plan-aware bundle budget and explicit redirect/controlled-error coverage.
+The generated function bundle, config, build metadata, size report, and runtime manifest are written under the ignored `.cloudflare/` directory. Required CI uploads those outputs for inspection.
 
 Run a specific spec:
 
@@ -141,7 +151,7 @@ Checked-in config:
 
 - `wrangler.toml`
 - `functions/[[path]].js`
-- `package.json` deploy, bundle, and runtime-test scripts
+- `package.json` deploy, bundle, size, and runtime-test scripts
 - lockfile-pinned Wrangler dependency
 
 Expected environment variables:
@@ -149,6 +159,7 @@ Expected environment variables:
 - `CLOUDFLARE_API_TOKEN` or a compatible Pages token
 - `CLOUDFLARE_PAGES_PROJECT` to override the default project name
 - `CLOUDFLARE_PAGES_BRANCH` to override the branch name
+- `CLOUDFLARE_WORKERS_PLAN=paid` only for a paid Workers plan; otherwise the Free-plan budget is enforced
 
 Deploy manually:
 
@@ -156,7 +167,7 @@ Deploy manually:
 yarn deploy:cloudflare
 ```
 
-The deployment command runs typechecking, the application build, Pages Function bundling, the direct adapter contract, and the staged Pages runtime contract before invoking the pinned Wrangler binary.
+The deployment command runs typechecking, the application build, Pages Function bundling, the size budget, the direct adapter contract, and the staged Pages runtime contract before invoking the pinned Wrangler binary.
 
 ## Docker
 
@@ -185,7 +196,7 @@ e2e/          Playwright specs and visual baselines
 public/       Static assets and browser build output
 build/        Remix server build produced by yarn build
 functions/    Cloudflare Pages Functions request adapter
-scripts/      Build, staging, and runtime-contract automation
+scripts/      Build, staging, budget, and runtime-contract automation
 ```
 
 ## Development Notes

--- a/app/routes/contact.tsx
+++ b/app/routes/contact.tsx
@@ -1,0 +1,7 @@
+import { redirect } from "@remix-run/node"
+
+export const loader = () => redirect("/services", 301)
+
+export default function ContactRedirect() {
+  return null
+}

--- a/docs/architecture/cloudflare-pages-ssr.md
+++ b/docs/architecture/cloudflare-pages-ssr.md
@@ -244,9 +244,9 @@ The default plan is `free`. `CLOUDFLARE_WORKERS_PLAN=paid` is an explicit opt-in
 Both plans reserve 20% internal headroom:
 
 | Plan | Platform gzip limit | Enforced gzip budget |
-| ---- | -------------------: | -------------------: |
-| Free |         3,000,000 B |         2,400,000 B |
-| Paid |        10,000,000 B |         8,000,000 B |
+| ---- | ------------------: | -------------------: |
+| Free |         3,000,000 B |          2,400,000 B |
+| Paid |        10,000,000 B |          8,000,000 B |
 
 The platform's 64,000,000-byte uncompressed limit is enforced at an internal budget of 51,200,000 bytes.
 

--- a/docs/architecture/cloudflare-pages-ssr.md
+++ b/docs/architecture/cloudflare-pages-ssr.md
@@ -1,6 +1,6 @@
 # Cloudflare Pages SSR Architecture
 
-- **Status:** Accepted baseline
+- **Status:** Accepted and implemented baseline
 - **Date:** 2026-08-03
 - **Issue:** #56
 - **Decision scope:** Production runtime, deployment artifacts, compatibility boundaries, and validation responsibilities
@@ -9,7 +9,7 @@
 
 Micrantha Web is a server-rendered Remix 2 application deployed to Cloudflare Pages. The repository also supports local Node serving through `remix-serve`, a Docker image, and Makefile wrappers. Those paths are useful for development and portability, but they do not execute the same adapter or runtime used by production.
 
-The production path is currently defined by:
+The production path is defined by:
 
 - `wrangler.toml`, including `pages_build_output_dir`, compatibility date, and `nodejs_compat`;
 - `functions/[[path]].js`, which creates the Remix request handler;
@@ -17,13 +17,13 @@ The production path is currently defined by:
 - `public/`, containing static assets and the browser build;
 - Cloudflare Pages Functions, which bundles the root `functions/` directory into a Worker.
 
-Current browser tests start `remix-serve`. That validates the Remix application and production build, but it does not prove that the Pages Function bundles, starts, preserves headers, or behaves correctly under the Workers runtime.
+Browser tests start `remix-serve` for fast application-level coverage. Separate adapter and workerd contracts prove that the Pages Function bundles, starts, preserves headers, and behaves correctly under the Workers runtime.
 
 ## Decision
 
 Cloudflare Pages Functions is the authoritative production runtime.
 
-The repository must treat the following pipeline as the production contract:
+The repository treats the following pipeline as the production contract:
 
 ```text
 source
@@ -31,6 +31,10 @@ source
   -> Tailwind CSS build
   -> Remix browser and server build
   -> Pages Functions bundle
+  -> compressed and raw Worker budget
+  -> source-isolated advanced-mode Pages stage
+  -> pinned Wrangler compatibility-aware final bundle
+  -> workerd runtime contract
   -> public static assets plus Worker artifact
   -> Cloudflare Pages request
   -> functions/[[path]].js
@@ -38,7 +42,7 @@ source
   -> streamed response
 ```
 
-A change is production-compatible only when it passes the Pages Functions build and runtime contract. Passing through `remix-serve`, the Remix development server, or Docker alone is insufficient.
+A change is production-compatible only when it passes the Pages Functions build, bundle budget, adapter contract, and workerd runtime contract. Passing through `remix-serve`, the Remix development server, or Docker alone is insufficient.
 
 ## Source of truth
 
@@ -58,9 +62,9 @@ Cloudflare dashboard configuration must not silently diverge from the checked-in
 
 `functions/[[path]].js` is the production request adapter. It imports the generated Remix server build and translates the Pages Function context into a Remix request.
 
-The adapter must depend only on declared packages and generated deployment artifacts. It must not rely on transitive dependency hoisting, TypeScript source, content source files, or compiler packages at request time.
+The adapter depends only on declared packages and generated deployment artifacts. It must not rely on transitive dependency hoisting, TypeScript source, content source files, or compiler packages at request time.
 
-### Build artifacts
+### Build and runtime artifacts
 
 The production deployment consists of:
 
@@ -68,11 +72,20 @@ The production deployment consists of:
 - the bundled Pages Function generated from `functions/`;
 - the generated Remix server build consumed by that Function during bundling.
 
-Source `.tsx`, `.md`, and `.mdx` files are build inputs, not runtime dependencies.
+The runtime contract stages only:
+
+- the static `public/` tree;
+- the generated Worker as advanced-mode `public/_worker.js`;
+- generated Worker route and build metadata;
+- `wrangler.toml`.
+
+The stage manifest records the byte size and SHA-256 digest of every file. It rejects `app/`, `build/`, `functions/`, and `node_modules/` paths. Source `.tsx`, `.md`, and `.mdx` files are build inputs, not runtime dependencies.
 
 ## Runtime compatibility boundary
 
 `nodejs_compat` is permitted only for APIs required by the current Remix server build or adapter. New Node-specific runtime dependencies require explicit review.
+
+The generated intermediate Worker preserves Node built-in imports such as `crypto`, `stream`, `util`, and `string_decoder`. Therefore, pinned Wrangler performs a final compatibility-aware bundle before workerd starts. `--no-bundle` is not a valid runtime path for this artifact.
 
 The application should prefer Web Platform APIs available in both Workers and modern Node runtimes:
 
@@ -84,25 +97,26 @@ The application should prefer Web Platform APIs available in both Workers and mo
 
 Direct filesystem access, child processes, native addons, and assumptions about a writable local filesystem are prohibited in request handling.
 
-The compatibility date is an operational API version. Updating it is a production change and must pass the Pages adapter suite before merge.
+The compatibility date is an operational API version. Updating it is a production change and must pass the complete Pages contract before merge.
 
 ## Request and response contract
 
-The Pages runtime must preserve the following externally observable behavior:
+The Pages runtime preserves the following externally observable behavior:
 
 ### Rendering
 
 - direct requests return meaningful server-rendered HTML;
 - normal browser requests may stream;
 - bot requests may wait for the full stream according to `app/entry.server.tsx`;
-- primary content must not require hydration unless a feature explicitly documents that trade-off.
+- primary content does not require hydration unless a feature explicitly documents that trade-off.
 
 ### Status and routing
 
 - successful routes preserve their intended status;
 - unknown routes return 404;
-- redirects preserve status and `Location`;
-- controlled server failures return the intended error document and status.
+- the legacy `/contact` path permanently redirects to `/services` with its `Location` preserved;
+- unsupported mutation requests return a controlled 405 error document;
+- redirect and error behavior are validated through both the direct adapter and workerd.
 
 ### Headers
 
@@ -121,15 +135,17 @@ The Pages runtime must preserve the following externally observable behavior:
 
 Application code defines response cache policy. Cloudflare may enforce or transform caching only through documented platform configuration.
 
-The adapter suite must verify representative `Cache-Control` behavior. Future authenticated, preview, draft, or user-specific routes must default to non-shared caching until explicitly classified.
+The adapter suite verifies representative `Cache-Control` behavior. Future authenticated, preview, draft, or user-specific routes must default to non-shared caching until explicitly classified.
 
-Per-response CSP nonces require the HTML document and CSP header to remain one cache object. Tests must detect header/body recombination or policy loss.
+Per-response CSP nonces require the HTML document and CSP header to remain one cache object. Tests detect policy loss and header/body nonce mismatches.
 
 ## Environment and analytics
 
 Runtime configuration is resolved through the Pages Function context and request environment. Secrets and bindings are not committed.
 
-The analytics identifier is optional. Missing analytics configuration must not prevent rendering. Adding a new runtime binding requires documentation of:
+The analytics identifier is optional. Missing analytics configuration must not prevent rendering. The runtime contract injects a test identifier and verifies that the Pages binding reaches the rendered response.
+
+Adding a new runtime binding requires documentation of:
 
 - its owner;
 - preview and production behavior;
@@ -142,7 +158,13 @@ The analytics identifier is optional. Missing analytics configuration must not p
 
 **Role:** Authoritative production runtime and deployment contract.
 
-Must be exercised by CI through a pinned Wrangler build and local Pages runtime harness.
+Required CI uses pinned Wrangler to build the Pages Function, enforce its budget, stage an advanced-mode Worker, and execute it under workerd.
+
+### Direct adapter contract
+
+**Role:** Fast request-adapter diagnostic.
+
+It imports `functions/[[path]].js` against the generated Remix build and verifies representative route, binding, status, header, redirect, and method-error behavior. It does not substitute for workerd.
 
 ### `remix-serve`
 
@@ -160,7 +182,7 @@ Development-only CSP allowances and WebSocket behavior must not leak into produc
 
 **Role:** Local Node portability and optional deployment-parity experiment.
 
-The current image runs `remix-serve`; it is not the Cloudflare production artifact. Docker documentation must state that distinction. If the image is retained as an operational artifact, it requires its own dependency and vulnerability policy.
+The current image runs `remix-serve`; it is not the Cloudflare production artifact. Docker documentation states that distinction. If the image is retained as an operational artifact, it requires its own dependency and vulnerability policy.
 
 ### Makefile
 
@@ -170,53 +192,69 @@ Package scripts and checked-in platform configuration remain authoritative. Make
 
 ## Toolchain requirements
 
-Wrangler must be declared and lockfile-controlled. Production compatibility checks and deployment scripts must not fetch an unspecified Wrangler version through `npx`.
+Wrangler is declared and lockfile-controlled. Production compatibility checks and deployment scripts must not fetch an unspecified Wrangler version through `npx`.
 
-The Pages Function adapter must use a direct, intentional dependency. The implementation must decide whether to:
-
-1. declare `@remix-run/server-runtime` directly; or
-2. use a public Cloudflare/Remix adapter package that owns the request-handler boundary.
-
-Relying on a transitive package being hoisted is not acceptable.
+`@remix-run/server-runtime` is a direct dependency because the Pages Function adapter owns that request-handler boundary. Relying on transitive dependency hoisting is prohibited.
 
 ## CI contract
 
-The required Pages adapter job will:
+The required Quality job:
 
-1. install dependencies with the frozen lockfile;
-2. build CSS and Remix production artifacts;
-3. bundle Pages Functions with the pinned Wrangler version and checked-in configuration;
-4. record Worker bundle metadata and size;
-5. start the bundled application with `wrangler pages dev` or an equivalent Workers-runtime harness;
-6. run HTTP contract tests against that runtime;
-7. fail on unresolved imports, unsupported runtime APIs, missing assets, incorrect statuses, or header regressions.
+1. installs dependencies with the frozen lockfile;
+2. validates repository formatting, lint, and types;
+3. builds CSS and Remix production artifacts;
+4. verifies the pinned Wrangler version;
+5. bundles Pages Functions with checked-in configuration;
+6. enforces compressed and raw Worker budgets;
+7. uploads Worker bundle metadata and the size report;
+8. runs the direct adapter contract;
+9. stages the source-isolated Pages runtime;
+10. starts workerd through pinned Wrangler;
+11. runs HTTP contracts against that runtime;
+12. uploads the deterministic runtime manifest.
 
-The baseline suite must cover:
+The baseline suite covers:
 
 - `/`;
-- one representative nested route;
+- a representative nested article route;
 - a bot request;
+- the `/contact` redirect;
 - a 404;
-- a controlled error route or test fixture;
-- a redirect;
+- a controlled 405 method error;
 - CSP nonce/header pairing;
-- cache headers;
-- static CSS and asset resolution;
-- canonical metadata and JSON-LD.
+- cache and security headers;
+- environment binding propagation;
+- static CSS and generated browser asset resolution;
+- canonical metadata and JSON-LD through existing route/browser contracts.
 
-The harness should run from a staged deployment context where practical, proving that source files and build-only packages are unnecessary at request time.
-
-Issue #55 will extend this established harness with MDX-specific and JavaScript-disabled article tests. Those extension tests are not part of the baseline closure criteria for #56.
+Issue #55 may extend this established harness with MDX-specific and JavaScript-disabled article tests without redefining the production topology.
 
 ## Bundle budget
 
-The first implementation slice must record the current compressed and uncompressed Worker size. The enforced limit should preserve explicit headroom below the applicable Cloudflare plan limit.
+The bundle gate measures the generated `.cloudflare/functions/index.js` artifact before deployment:
 
-Subsequent architectural changes must report their delta. Browser route splitting does not guarantee equivalent Worker splitting, so server bundle growth must be measured independently.
+- raw bytes;
+- deterministic gzip level-9 bytes;
+- platform limits for the selected plan;
+- internal budgets;
+- remaining headroom.
+
+The default plan is `free`. `CLOUDFLARE_WORKERS_PLAN=paid` is an explicit opt-in for deployments backed by a paid Workers plan.
+
+Both plans reserve 20% internal headroom:
+
+| Plan | Platform gzip limit | Enforced gzip budget |
+| ---- | -------------------: | -------------------: |
+| Free |         3,000,000 B |         2,400,000 B |
+| Paid |        10,000,000 B |         8,000,000 B |
+
+The platform's 64,000,000-byte uncompressed limit is enforced at an internal budget of 51,200,000 bytes.
+
+The generated `.cloudflare/functions/size-report.json` is uploaded with CI artifacts. Subsequent architectural changes must expose their size effect through the report. Browser route splitting does not imply equivalent Worker splitting, so server bundle growth is measured independently.
 
 ## Security considerations
 
-The production adapter is part of the trust boundary. Review must include:
+The production adapter is part of the trust boundary. Review includes:
 
 - declared dependency provenance;
 - compatibility flags;
@@ -225,33 +263,36 @@ The production adapter is part of the trust boundary. Review must include:
 - error-path header behavior;
 - source-map handling;
 - accidental inclusion of source content or build-time tooling;
-- cache behavior for any future non-public route.
+- cache behavior for future non-public routes;
+- Worker size growth that could force an unsafe or unplanned platform change.
 
-Detailed CSP and cross-origin policy hardening remains owned by #57, but the baseline adapter tests must prove that current headers survive production execution.
+Detailed CSP and cross-origin policy hardening remains owned by #57, but the baseline adapter and workerd tests prove that current headers survive production execution.
 
 ## Consequences
 
 ### Positive
 
-- Cloudflare compatibility becomes measurable rather than assumed.
-- MDX and framework migrations gain a stable production acceptance boundary.
-- Runtime-only and build-only dependencies become distinguishable.
-- deployment documentation, scripts, and CI converge on one topology.
-- Worker growth and compatibility-date changes become reviewable.
+- Cloudflare compatibility is measurable rather than assumed.
+- MDX and framework migrations have a stable production acceptance boundary.
+- Runtime-only and build-only dependencies are distinguishable.
+- Deployment documentation, scripts, and CI converge on one topology.
+- Worker growth and compatibility-date changes are reviewable.
+- Redirect and error behavior cannot silently diverge between Node and workerd.
 
 ### Costs
 
-- CI gains another build/runtime path in addition to browser tests.
-- Wrangler becomes a repository-managed dependency.
-- some Node-oriented dependencies may require replacement or explicit compatibility justification.
-- maintaining both Docker and Cloudflare paths requires clear scope to prevent false parity claims.
+- CI maintains an additional runtime path beyond browser tests.
+- Wrangler is a repository-managed dependency.
+- Node-oriented dependencies may require replacement or explicit compatibility justification.
+- Maintaining both Docker and Cloudflare paths requires clear scope to prevent false parity claims.
+- The current Yarn cache is large and should be optimized separately without weakening the production contract.
 
-## Follow-up implementation
+## Extension rules
 
-1. Pin Wrangler and replace unpinned invocations.
-2. resolve the direct Remix runtime dependency decision;
-3. add Pages Function bundle and runtime scripts;
-4. record the Worker bundle baseline and budget;
-5. add the Cloudflare adapter CI job and HTTP contract suite;
-6. align README, Docker, Makefile, and package script descriptions;
-7. extend the harness from #55, #57, and #58 without redefining the production topology.
+Future work from #55, #57, #58, or framework modernization may extend the established contract, but must not:
+
+- make `remix-serve` the production authority;
+- bypass the bundle budget;
+- remove source-isolation guarantees;
+- introduce unpinned runtime tooling;
+- weaken no-JavaScript content or current security-header coverage.

--- a/package.json
+++ b/package.json
@@ -21,11 +21,12 @@
     "start": "remix-serve build/index.js",
     "test:cloudflare:adapter": "node scripts/test-cloudflare-adapter.js",
     "test:cloudflare:runtime": "node scripts/stage-cloudflare-runtime.js && node scripts/test-cloudflare-runtime.js",
+    "test:cloudflare:size": "node scripts/check-cloudflare-bundle-size.js",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:mobile": "playwright test --project=mobile-chromium",
     "typecheck": "tsc -b",
-    "deploy:cloudflare": "yarn typecheck && yarn build && yarn cloudflare:functions:build && yarn test:cloudflare:adapter && yarn test:cloudflare:runtime && wrangler pages deploy public --project-name ${CLOUDFLARE_PAGES_PROJECT:-micrantha-web} --branch ${CLOUDFLARE_PAGES_BRANCH:-main} --upload-source-maps"
+    "deploy:cloudflare": "yarn typecheck && yarn build && yarn cloudflare:functions:build && yarn test:cloudflare:size && yarn test:cloudflare:adapter && yarn test:cloudflare:runtime && wrangler pages deploy public --project-name ${CLOUDFLARE_PAGES_PROJECT:-micrantha-web} --branch ${CLOUDFLARE_PAGES_BRANCH:-main} --upload-source-maps"
   },
   "dependencies": {
     "@remix-run/node": "2.17.4",

--- a/scripts/check-cloudflare-bundle-size.js
+++ b/scripts/check-cloudflare-bundle-size.js
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict"
+import { readFile, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { gzipSync } from "node:zlib"
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+)
+const workerPath = path.join(
+  repositoryRoot,
+  ".cloudflare",
+  "functions",
+  "index.js",
+)
+const reportPath = path.join(
+  repositoryRoot,
+  ".cloudflare",
+  "functions",
+  "size-report.json",
+)
+
+const plan = (process.env.CLOUDFLARE_WORKERS_PLAN ?? "free").toLowerCase()
+const compressedLimits = {
+  free: 3_000_000,
+  paid: 10_000_000,
+}
+const uncompressedLimit = 64_000_000
+const budgetRatio = 0.8
+
+assert.ok(
+  Object.hasOwn(compressedLimits, plan),
+  `Unsupported CLOUDFLARE_WORKERS_PLAN=${plan}; expected free or paid`,
+)
+
+const worker = await readFile(workerPath).catch(() => {
+  throw new Error(
+    "Missing .cloudflare/functions/index.js; run yarn cloudflare:functions:build first",
+  )
+})
+const gzipBytes = gzipSync(worker, { level: 9 }).byteLength
+const rawBytes = worker.byteLength
+const compressedPlatformLimitBytes = compressedLimits[plan]
+const compressedBudgetBytes = Math.floor(
+  compressedPlatformLimitBytes * budgetRatio,
+)
+const uncompressedBudgetBytes = Math.floor(uncompressedLimit * budgetRatio)
+
+const report = {
+  schemaVersion: 1,
+  plan,
+  budgetRatio,
+  artifact: path.relative(repositoryRoot, workerPath).split(path.sep).join("/"),
+  rawBytes,
+  gzipBytes,
+  limits: {
+    compressedPlatformLimitBytes,
+    uncompressedPlatformLimitBytes: uncompressedLimit,
+  },
+  budgets: {
+    compressedBytes: compressedBudgetBytes,
+    uncompressedBytes: uncompressedBudgetBytes,
+  },
+  headroom: {
+    compressedBytes: compressedBudgetBytes - gzipBytes,
+    uncompressedBytes: uncompressedBudgetBytes - rawBytes,
+  },
+}
+
+await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`)
+
+assert.ok(
+  gzipBytes <= compressedBudgetBytes,
+  `Cloudflare Worker gzip size ${gzipBytes} exceeds the ${plan} plan budget ${compressedBudgetBytes}`,
+)
+assert.ok(
+  rawBytes <= uncompressedBudgetBytes,
+  `Cloudflare Worker raw size ${rawBytes} exceeds the budget ${uncompressedBudgetBytes}`,
+)
+
+console.log(
+  `Cloudflare Worker size passed (${rawBytes} raw bytes, ${gzipBytes} gzip bytes, ${report.headroom.compressedBytes} gzip bytes headroom)`,
+)

--- a/scripts/test-cloudflare-adapter.js
+++ b/scripts/test-cloudflare-adapter.js
@@ -7,8 +7,12 @@ const { onRequest } = await import("../functions/[[path]].js")
 const origin = "https://micrantha.example"
 const analyticsId = "adapter-contract-test"
 
-async function request(pathname, { userAgent = "adapter-contract" } = {}) {
+async function request(
+  pathname,
+  { userAgent = "adapter-contract", method = "GET" } = {},
+) {
   const request = new Request(new URL(pathname, origin), {
+    method,
     headers: {
       "User-Agent": userAgent,
     },
@@ -77,6 +81,10 @@ assert.match(home.body, /id="content"/)
 assert.match(home.body, new RegExp(`data-website-id="${analyticsId}"`))
 assertDocumentHeaders(home.response, home.body)
 
+const contactRedirect = await read("/contact")
+assert.equal(contactRedirect.response.status, 301)
+assert.equal(contactRedirect.response.headers.get("location"), "/services")
+
 const article = await read("/blog/ai-pipelines-need-control-boundaries")
 assert.equal(article.response.status, 200)
 assert.match(article.body, /AI Pipelines Need Control Boundaries/)
@@ -92,6 +100,13 @@ const botArticle = await read("/blog/ai-pipelines-need-control-boundaries", {
 assert.equal(botArticle.response.status, 200)
 assert.match(botArticle.body, /AI Pipelines Need Control Boundaries/)
 assertDocumentHeaders(botArticle.response, botArticle.body)
+
+const methodNotAllowed = await read("/services", { method: "POST" })
+assert.equal(methodNotAllowed.response.status, 405)
+assert.match(methodNotAllowed.body, /405|Method Not Allowed/i)
+assertDocumentHeaders(methodNotAllowed.response, methodNotAllowed.body, {
+  requireNonce: false,
+})
 
 const missing = await read("/this-route-does-not-exist")
 assert.equal(missing.response.status, 404)

--- a/scripts/test-cloudflare-runtime.js
+++ b/scripts/test-cloudflare-runtime.js
@@ -211,6 +211,10 @@ try {
   assert.match(home.body, /https:\/\/micrantha\.com/)
   assertDocumentHeaders(home.response, home.body)
 
+  const contactRedirect = await readRuntime("/contact")
+  assert.equal(contactRedirect.response.status, 301)
+  assert.equal(contactRedirect.response.headers.get("location"), "/services")
+
   const css = await readRuntime("/tailwind.css")
   assert.equal(css.response.status, 200)
   assert.match(css.response.headers.get("content-type") ?? "", /^text\/css\b/)
@@ -249,6 +253,13 @@ try {
   assert.equal(botArticle.response.status, 200)
   assert.match(botArticle.body, /AI Pipelines Need Control Boundaries/)
   assertDocumentHeaders(botArticle.response, botArticle.body)
+
+  const methodNotAllowed = await readRuntime("/services", { method: "POST" })
+  assert.equal(methodNotAllowed.response.status, 405)
+  assert.match(methodNotAllowed.body, /405|Method Not Allowed/i)
+  assertDocumentHeaders(methodNotAllowed.response, methodNotAllowed.body, {
+    requireNonce: false,
+  })
 
   const missing = await readRuntime("/this-route-does-not-exist")
   assert.equal(missing.response.status, 404)


### PR DESCRIPTION
Superseded by PR #81 for the bundle-budget/cache work and by a clean replacement branch from current `main` for the remaining #56 contracts. Closing this conflicting branch to avoid duplicate implementation.