### PR TITLE
Enforce Cloudflare Worker bundle budgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 24
-          cache: yarn
-          cache-dependency-path: yarn.lock
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -69,6 +67,9 @@ jobs:
 
       - name: Bundle Cloudflare Pages Function
         run: yarn cloudflare:functions:build
+
+      - name: Enforce Cloudflare Worker bundle budget
+        run: yarn test:cloudflare:bundle-budget
 
       - name: Report Pages Function bundle files
         run: find .cloudflare/functions -type f -printf '%p %s bytes\n' | sort
@@ -109,8 +110,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 24
-          cache: yarn
-          cache-dependency-path: yarn.lock
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --non-interactive

--- a/README.md
+++ b/README.md
@@ -46,22 +46,23 @@ Open `http://localhost:3000`.
 
 ## Scripts
 
-| Command                           | Purpose                                                        |
-| --------------------------------- | -------------------------------------------------------------- |
-| `yarn dev`                        | Run Remix and Tailwind in watch mode                           |
-| `yarn build`                      | Build CSS and Remix for production                             |
-| `yarn cloudflare:functions:build` | Bundle the Pages Function with pinned Wrangler                 |
-| `yarn cloudflare:runtime:stage`   | Stage only the deployable Pages assets and prebuilt Worker     |
-| `yarn start`                      | Serve the production build locally through `remix-serve`       |
-| `yarn lint`                       | Run ESLint                                                     |
-| `yarn lint:fix`                   | Auto-fix lint issues                                           |
-| `yarn typecheck`                  | Run the TypeScript build check                                 |
-| `yarn test:cloudflare:adapter`    | Exercise the built Pages Function entry directly               |
-| `yarn test:cloudflare:runtime`    | Exercise the staged Worker through the local Pages runtime     |
-| `yarn test:e2e`                   | Run the full Playwright suite                                  |
-| `yarn test:e2e:mobile`            | Run the mobile Playwright project only                         |
-| `yarn test:e2e:headed`            | Run Playwright in headed mode                                  |
-| `yarn deploy:cloudflare`          | Validate, bundle, runtime-test, and deploy to Cloudflare Pages |
+| Command                              | Purpose                                                        |
+| ------------------------------------ | -------------------------------------------------------------- |
+| `yarn dev`                           | Run Remix and Tailwind in watch mode                           |
+| `yarn build`                         | Build CSS and Remix for production                             |
+| `yarn cloudflare:functions:build`    | Bundle the Pages Function with pinned Wrangler                 |
+| `yarn cloudflare:runtime:stage`      | Stage only the deployable Pages assets and prebuilt Worker     |
+| `yarn start`                         | Serve the production build locally through `remix-serve`       |
+| `yarn lint`                          | Run ESLint                                                     |
+| `yarn lint:fix`                      | Auto-fix lint issues                                           |
+| `yarn typecheck`                     | Run the TypeScript build check                                 |
+| `yarn test:cloudflare:adapter`       | Exercise the built Pages Function entry directly               |
+| `yarn test:cloudflare:bundle-budget` | Enforce raw and gzip Worker size budgets                       |
+| `yarn test:cloudflare:runtime`       | Exercise the staged Worker through the local Pages runtime     |
+| `yarn test:e2e`                      | Run the full Playwright suite                                  |
+| `yarn test:e2e:mobile`               | Run the mobile Playwright project only                         |
+| `yarn test:e2e:headed`               | Run Playwright in headed mode                                  |
+| `yarn deploy:cloudflare`             | Validate, budget, runtime-test, and deploy to Cloudflare Pages |
 
 ## Testing
 
@@ -86,11 +87,12 @@ yarn test:cloudflare:adapter
 
 This imports the checked-in Pages Function entry against the generated Remix server build and verifies representative SSR, binding, status, CSP nonce, cache, and security-header behavior. It is a fast adapter-level diagnostic, not a Workers-runtime substitute.
 
-Bundle the Pages Function using the repository-pinned Wrangler version, then run the authoritative local runtime contract:
+Bundle the Pages Function using the repository-pinned Wrangler version, enforce its size budgets, then run the authoritative local runtime contract:
 
 ```sh
 yarn build
 yarn cloudflare:functions:build
+yarn test:cloudflare:bundle-budget
 yarn test:cloudflare:runtime
 ```
 
@@ -103,7 +105,11 @@ The runtime test creates an ignored `.cloudflare/runtime/` stage containing only
 
 It deliberately excludes `app/`, `build/`, `functions/`, and `node_modules/` from the staged runtime payload. Wrangler consumes that source-free stage through Pages advanced mode, performs the final compatibility-aware bundle required by the Worker’s `nodejs_compat` imports, and starts workerd with `pages dev public`. The contract then verifies SSR, nested and bot routes, 404 behavior, CSP nonce pairing, cache and security headers, static CSS, and a generated browser bundle.
 
-The generated function bundle, config, build metadata, and runtime manifest are written under the ignored `.cloudflare/` directory. Required CI uploads those outputs for inspection. Issue #56 retains the remaining plan-aware bundle budget and explicit redirect/controlled-error coverage.
+`config/cloudflare-bundle-budget.json` records the current raw and gzip baselines, selected platform envelope, and enforced repository budgets. The budget command writes `.cloudflare/functions/bundle-budget.json` with actual sizes and baseline deltas; required CI uploads it with the generated Function bundle.
+
+The generated function bundle, config, build metadata, budget report, and runtime manifest are written under the ignored `.cloudflare/` directory. Required CI uploads those outputs for inspection. Required jobs use clean frozen installs instead of setup-node’s Yarn cache because the Wrangler dependency graph produced approximately 1.9 GB cache archives; the lockfile remains the reproducibility control.
+
+Issue #56 retains explicit redirect and controlled-error coverage, dashboard/configuration parity, production startup measurement, and deeper CDN/cache validation.
 
 Run a specific spec:
 
@@ -141,7 +147,8 @@ Checked-in config:
 
 - `wrangler.toml`
 - `functions/[[path]].js`
-- `package.json` deploy, bundle, and runtime-test scripts
+- `config/cloudflare-bundle-budget.json`
+- `package.json` deploy, bundle, budget, and runtime-test scripts
 - lockfile-pinned Wrangler dependency
 
 Expected environment variables:
@@ -156,7 +163,7 @@ Deploy manually:
 yarn deploy:cloudflare
 ```
 
-The deployment command runs typechecking, the application build, Pages Function bundling, the direct adapter contract, and the staged Pages runtime contract before invoking the pinned Wrangler binary.
+The deployment command runs typechecking, the application build, Pages Function bundling, bundle-budget enforcement, the direct adapter contract, and the staged Pages runtime contract before invoking the pinned Wrangler binary.
 
 ## Docker
 
@@ -180,6 +187,7 @@ make run
 
 ```text
 app/          Remix routes, components, services, and utilities
+config/       Enforced runtime and bundle policy
 docs/         Architecture and operational decisions
 e2e/          Playwright specs and visual baselines
 public/       Static assets and browser build output

--- a/config/cloudflare-bundle-budget.json
+++ b/config/cloudflare-bundle-budget.json
@@ -1,0 +1,17 @@
+{
+  "planCompatibility": "workers-free",
+  "platformLimits": {
+    "compressedBytes": 3000000,
+    "uncompressedBytes": 64000000
+  },
+  "baseline": {
+    "measuredAt": "2026-08-03",
+    "wranglerVersion": "4.114.0",
+    "compressedBytes": 466338,
+    "uncompressedBytes": 2356613
+  },
+  "budgets": {
+    "compressedBytes": 2500000,
+    "uncompressedBytes": 3000000
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,12 +20,13 @@
     "lint:fix": "eslint --fix .",
     "start": "remix-serve build/index.js",
     "test:cloudflare:adapter": "node scripts/test-cloudflare-adapter.js",
+    "test:cloudflare:bundle-budget": "node scripts/check-cloudflare-bundle-budget.js",
     "test:cloudflare:runtime": "node scripts/stage-cloudflare-runtime.js && node scripts/test-cloudflare-runtime.js",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:mobile": "playwright test --project=mobile-chromium",
     "typecheck": "tsc -b",
-    "deploy:cloudflare": "yarn typecheck && yarn build && yarn cloudflare:functions:build && yarn test:cloudflare:adapter && yarn test:cloudflare:runtime && wrangler pages deploy public --project-name ${CLOUDFLARE_PAGES_PROJECT:-micrantha-web} --branch ${CLOUDFLARE_PAGES_BRANCH:-main} --upload-source-maps"
+    "deploy:cloudflare": "yarn typecheck && yarn build && yarn cloudflare:functions:build && yarn test:cloudflare:bundle-budget && yarn test:cloudflare:adapter && yarn test:cloudflare:runtime && wrangler pages deploy public --project-name ${CLOUDFLARE_PAGES_PROJECT:-micrantha-web} --branch ${CLOUDFLARE_PAGES_BRANCH:-main} --upload-source-maps"
   },
   "dependencies": {
     "@remix-run/node": "2.17.4",

--- a/scripts/check-cloudflare-bundle-budget.js
+++ b/scripts/check-cloudflare-bundle-budget.js
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict"
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { gzipSync } from "node:zlib"
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+const bundlePath = path.join(root, ".cloudflare/functions/index.js")
+const budgetPath = path.join(root, "config/cloudflare-bundle-budget.json")
+const reportPath = path.join(root, ".cloudflare/functions/bundle-budget.json")
+
+const [bundle, budgetDocument] = await Promise.all([
+  readFile(bundlePath),
+  readFile(budgetPath, "utf8"),
+])
+const budget = JSON.parse(budgetDocument)
+const compressedBytes = gzipSync(bundle, { level: 9 }).byteLength
+const uncompressedBytes = bundle.byteLength
+
+function assertPositiveInteger(value, label) {
+  assert.ok(
+    Number.isInteger(value) && value > 0,
+    `${label} must be a positive integer`,
+  )
+}
+
+for (const [label, value] of [
+  ["platform compressed limit", budget.platformLimits.compressedBytes],
+  ["platform uncompressed limit", budget.platformLimits.uncompressedBytes],
+  ["baseline compressed size", budget.baseline.compressedBytes],
+  ["baseline uncompressed size", budget.baseline.uncompressedBytes],
+  ["compressed budget", budget.budgets.compressedBytes],
+  ["uncompressed budget", budget.budgets.uncompressedBytes],
+]) {
+  assertPositiveInteger(value, label)
+}
+
+assert.ok(
+  budget.baseline.compressedBytes <= budget.budgets.compressedBytes,
+  "the compressed baseline must fit within the repository budget",
+)
+assert.ok(
+  budget.baseline.uncompressedBytes <= budget.budgets.uncompressedBytes,
+  "the uncompressed baseline must fit within the repository budget",
+)
+assert.ok(
+  budget.budgets.compressedBytes < budget.platformLimits.compressedBytes,
+  "the repository compressed budget must preserve platform headroom",
+)
+assert.ok(
+  budget.budgets.uncompressedBytes < budget.platformLimits.uncompressedBytes,
+  "the repository uncompressed budget must preserve platform headroom",
+)
+assert.ok(
+  compressedBytes <= budget.budgets.compressedBytes,
+  `gzip-compressed Worker bundle ${compressedBytes} exceeds budget ${budget.budgets.compressedBytes}`,
+)
+assert.ok(
+  uncompressedBytes <= budget.budgets.uncompressedBytes,
+  `uncompressed Worker bundle ${uncompressedBytes} exceeds budget ${budget.budgets.uncompressedBytes}`,
+)
+
+const report = {
+  measuredAt: new Date().toISOString(),
+  planCompatibility: budget.planCompatibility,
+  baseline: budget.baseline,
+  platformLimits: budget.platformLimits,
+  budgets: budget.budgets,
+  actual: {
+    compressedBytes,
+    uncompressedBytes,
+    compressedDeltaBytes: compressedBytes - budget.baseline.compressedBytes,
+    uncompressedDeltaBytes:
+      uncompressedBytes - budget.baseline.uncompressedBytes,
+  },
+}
+
+await mkdir(path.dirname(reportPath), { recursive: true })
+await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`)
+
+console.log(
+  `Cloudflare Worker bundle: ${uncompressedBytes} bytes raw, ${compressedBytes} bytes gzip`,
+)
+console.log(
+  `Budgets: ${budget.budgets.uncompressedBytes} bytes raw, ${budget.budgets.compressedBytes} bytes gzip`,
+)


### PR DESCRIPTION
## Summary

- define raw and gzip size budgets for the generated Cloudflare Pages Worker
- record the current Wrangler 4.114.0 baseline and selected Workers Free compatibility envelope
- fail required CI when either repository budget is exceeded
- include measured sizes and baseline deltas in the existing Pages Function artifact
- require the budget gate before manual deployment
- stop persisting setup-node’s approximately 1.9 GB Yarn cache archive in required jobs

## Context

PR #79 already merged the source-isolated Pages/workerd runtime harness. This PR intentionally contains only the non-duplicated follow-up work recovered from superseded PR #78.

## Budget policy

Current baseline:

- raw Worker: 2,356,613 bytes
- gzip Worker: 466,338 bytes

Enforced repository budgets:

- raw Worker: 3,000,000 bytes
- gzip Worker: 2,500,000 bytes

Recorded platform envelope:

- Workers Free compressed limit: 3,000,000 bytes
- uncompressed limit: 64,000,000 bytes

The raw repository budget is intentionally much tighter than the platform ceiling so unexpected server-bundle growth remains visible during framework and MDX work.

## Validation

Required CI runs the budget check immediately after `wrangler pages functions build`. The validator:

- verifies all configured limits and baselines are positive integers
- verifies the recorded baseline fits the repository budgets
- verifies repository budgets preserve platform headroom
- measures raw and gzip bytes deterministically
- writes `.cloudflare/functions/bundle-budget.json`
- reports compressed and uncompressed deltas from the baseline

The existing adapter, staged runtime, and Playwright contracts remain unchanged.

## CI cache decision

The Wrangler dependency graph caused setup-node’s Yarn cache archive to grow to approximately 1.9 GB. Clean frozen installs remained bounded, so required jobs now avoid persisting that cache. The lockfile remains the reproducibility control.

Progresses #56; does not close it. Remaining work includes redirect and controlled-error fixtures, dashboard/configuration parity, production startup measurement, and deeper CDN/cache validation.