### PR TITLE
Correct asset routing in the Cloudflare runtime contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ Open `http://localhost:3000`.
 | `yarn dev`                           | Run Remix and Tailwind in watch mode                           |
 | `yarn build`                         | Build CSS and Remix for production                             |
 | `yarn cloudflare:functions:build`    | Bundle the Pages Function with pinned Wrangler                 |
-| `yarn cloudflare:runtime:stage`      | Stage only the deployable Pages assets and prebuilt Worker     |
+| `yarn cloudflare:runtime:stage`      | Stage static assets, the prebuilt Worker, and runtime metadata |
 | `yarn start`                         | Serve the production build locally through `remix-serve`       |
 | `yarn lint`                          | Run ESLint                                                     |
 | `yarn lint:fix`                      | Auto-fix lint issues                                           |
 | `yarn typecheck`                     | Run the TypeScript build check                                 |
 | `yarn test:cloudflare:adapter`       | Exercise the built Pages Function entry directly               |
 | `yarn test:cloudflare:bundle-budget` | Enforce raw and gzip Worker size budgets                       |
-| `yarn test:cloudflare:runtime`       | Exercise the staged Worker through the local Pages runtime     |
+| `yarn test:cloudflare:runtime`       | Exercise the clean staged artifact through workerd             |
 | `yarn test:e2e`                      | Run the full Playwright suite                                  |
 | `yarn test:e2e:mobile`               | Run the mobile Playwright project only                         |
 | `yarn test:e2e:headed`               | Run Playwright in headed mode                                  |
@@ -99,15 +99,19 @@ yarn test:cloudflare:runtime
 The runtime test creates an ignored `.cloudflare/runtime/` stage containing only:
 
 - `public/` static assets and browser output;
-- the generated Pages Worker staged as `public/_worker.js`;
+- the generated Pages Worker under `worker/index.js`;
 - generated Worker route and build metadata;
-- `wrangler.toml`.
+- derived runtime configuration preserving the checked-in compatibility date and flags.
 
-It deliberately excludes `app/`, `build/`, `functions/`, and `node_modules/` from the staged runtime payload. Wrangler consumes that source-free stage through Pages advanced mode, performs the final compatibility-aware bundle required by the Worker’s `nodejs_compat` imports, and starts workerd with `pages dev public`. The contract then verifies SSR, nested and bot routes, 404 behavior, CSP nonce pairing, cache and security headers, static CSS, and a generated browser bundle.
+The local harness uses Workers Static Assets with asset-first routing. Matching files are served before the Worker; unknown paths fall through to the exact precompiled Pages Functions Worker for Remix SSR. This preserves the Pages request boundary more faithfully than staging the catch-all generated Worker as advanced-mode `_worker.js`, where the Worker would control every request.
+
+It deliberately excludes `app/`, `build/`, `functions/`, `scripts/`, `node_modules/`, `package.json`, and `yarn.lock` from the staged runtime payload. The contract verifies SSR, nested and bot routes, canonical metadata and Article JSON-LD, 404 behavior, CSP nonce pairing, cache and security headers, static CSS, the web manifest, and a generated browser bundle.
 
 `config/cloudflare-bundle-budget.json` records the current raw and gzip baselines, selected platform envelope, and enforced repository budgets. The budget command writes `.cloudflare/functions/bundle-budget.json` with actual sizes and baseline deltas; required CI uploads it with the generated Function bundle.
 
 The generated function bundle, config, build metadata, budget report, and runtime manifest are written under the ignored `.cloudflare/` directory. Required CI uploads those outputs for inspection. Required jobs use clean frozen installs instead of setup-node’s Yarn cache because the Wrangler dependency graph produced approximately 1.9 GB cache archives; the lockfile remains the reproducibility control.
+
+See [Cloudflare Runtime Validation](docs/operations/cloudflare-runtime-validation.md) for the routing model, artifact boundary, and remaining deployment-level checks.
 
 Issue #56 retains explicit redirect and controlled-error coverage, dashboard/configuration parity, production startup measurement, and deeper CDN/cache validation.
 
@@ -199,5 +203,5 @@ scripts/      Build, staging, and runtime-contract automation
 ## Development Notes
 
 - Tailwind is compiled from `app/styles/app.css` into `public/tailwind.css`.
-- The philosophy triangle diagram is now served as SVG for sharper rendering.
+- The philosophy triangle diagram is served as SVG for sharper rendering.
 - This repository is mirrored from GitLab.

--- a/docs/operations/cloudflare-runtime-validation.md
+++ b/docs/operations/cloudflare-runtime-validation.md
@@ -1,0 +1,116 @@
+# Cloudflare Runtime Validation
+
+## Purpose
+
+The production contract is validated in three layers:
+
+1. `yarn build` produces the Remix browser and server artifacts.
+2. `yarn cloudflare:functions:build` uses the lockfile-pinned Wrangler version to compile the Pages Functions source into a Worker.
+3. `yarn test:cloudflare:runtime` stages and executes only the deployable runtime artifact through workerd.
+
+The direct adapter test remains useful for fast request-handler diagnostics. The staged runtime contract is the authoritative local compatibility gate.
+
+## Routing model
+
+Cloudflare Pages advanced mode gives `_worker.js` control of every request. A custom advanced-mode Worker must explicitly forward static asset requests to the `ASSETS` binding.
+
+The Worker produced by `wrangler pages functions build` contains the generated Pages Functions dispatcher, including a catch-all route. Staging that generated Worker directly as `_worker.js` changes the asset boundary: the Worker receives asset paths before the platform can apply Pages asset-first routing.
+
+The local contract therefore uses the equivalent Workers runtime permitted by the architecture decision:
+
+- the exact precompiled Pages Functions Worker remains unchanged;
+- Workers Static Assets serves matching files first;
+- unknown paths execute the Worker;
+- the `ASSETS` binding remains available to the generated dispatcher;
+- workerd executes the staged runtime with bundling disabled.
+
+This avoids the deprecated `wrangler pages dev --script-path` path and preserves the production request boundary more faithfully than advanced mode.
+
+## Clean runtime artifact
+
+The staging command creates `.cloudflare/runtime/` with only:
+
+```text
+.cloudflare/runtime/
+  manifest.json
+  wrangler.toml
+  metadata/
+    build-metadata.json
+    functions-config.json
+  public/
+    build/
+    icon/
+    tailwind.css
+    ...static assets
+  worker/
+    index.js
+    index.js.map
+```
+
+The derived runtime configuration preserves the checked-in Pages compatibility date and compatibility flags and adds:
+
+```toml
+main = "./worker/index.js"
+
+[assets]
+directory = "./public"
+binding = "ASSETS"
+run_worker_first = false
+```
+
+The staged runtime intentionally excludes:
+
+- `app/`;
+- `build/`;
+- `functions/`;
+- `scripts/`;
+- `node_modules/`;
+- `package.json`;
+- `yarn.lock`.
+
+Request handling therefore cannot read source TSX, import the unbundled Remix server build, resolve application packages, or invoke build-time tools.
+
+The manifest records every staged file's path, byte size, and SHA-256 digest together with the source compatibility configuration and routing policy.
+
+## Runtime contract
+
+The runtime test starts the staged artifact with `wrangler dev --no-bundle` on a dynamically allocated loopback port. It verifies:
+
+- complete SSR for `/`;
+- runtime configuration propagation;
+- a representative nested blog article;
+- canonical metadata and Article JSON-LD;
+- browser and bot responses;
+- 404 status and baseline security headers;
+- CSP nonce pairing on successful documents;
+- generated Tailwind CSS;
+- the web manifest;
+- a generated browser asset.
+
+Local Wrangler readiness time is logged only as diagnostic information. It is not equivalent to Cloudflare's production startup measurement and is not enforced as a production startup budget.
+
+## Bundle budgets
+
+`config/cloudflare-bundle-budget.json` records the current baseline, repository budgets, and selected platform-compatibility envelope.
+
+`yarn test:cloudflare:bundle-budget` measures raw and gzip-compressed Worker bytes, verifies repository headroom, and writes `.cloudflare/functions/bundle-budget.json` for CI inspection.
+
+## Commands
+
+```sh
+yarn build
+yarn cloudflare:functions:build
+yarn test:cloudflare:bundle-budget
+yarn test:cloudflare:adapter
+yarn test:cloudflare:runtime
+```
+
+## Remaining production checks
+
+The local runtime contract does not replace deployment-level validation. Follow-up work still owns:
+
+- dashboard and checked-in configuration parity;
+- production startup measurements;
+- explicit redirect and controlled-error fixtures;
+- deeper CDN cache behavior and nonce/header pairing;
+- the JavaScript-disabled representative MDX route.

--- a/scripts/stage-cloudflare-runtime.js
+++ b/scripts/stage-cloudflare-runtime.js
@@ -21,11 +21,13 @@ const cloudflareRoot = path.join(repositoryRoot, ".cloudflare")
 const bundleRoot = path.join(cloudflareRoot, "functions")
 const runtimeRoot = path.join(cloudflareRoot, "runtime")
 const runtimeAssets = path.join(runtimeRoot, "public")
+const runtimeWorker = path.join(runtimeRoot, "worker")
 const runtimeMetadata = path.join(runtimeRoot, "metadata")
+const pagesConfigPath = path.join(repositoryRoot, "wrangler.toml")
 
 const requiredInputs = [
   path.join(repositoryRoot, "public"),
-  path.join(repositoryRoot, "wrangler.toml"),
+  pagesConfigPath,
   path.join(bundleRoot, "index.js"),
   path.join(bundleRoot, "config.json"),
   path.join(bundleRoot, "build-metadata.json"),
@@ -39,19 +41,45 @@ for (const input of requiredInputs) {
   })
 }
 
+const pagesConfig = await readFile(pagesConfigPath, "utf8")
+const projectName = pagesConfig.match(/^name\s*=\s*"([^"]+)"\s*$/m)?.[1]
+const compatibilityDate = pagesConfig.match(
+  /^compatibility_date\s*=\s*"([^"]+)"\s*$/m,
+)?.[1]
+const compatibilityFlags = pagesConfig.match(
+  /^compatibility_flags\s*=\s*(\[[^\n]+\])\s*$/m,
+)?.[1]
+
+assert.ok(projectName, "expected name in the Pages Wrangler configuration")
+assert.ok(
+  compatibilityDate,
+  "expected compatibility_date in the Pages Wrangler configuration",
+)
+assert.ok(
+  compatibilityFlags,
+  "expected compatibility_flags in the Pages Wrangler configuration",
+)
+
 await rm(runtimeRoot, { recursive: true, force: true })
+await mkdir(runtimeWorker, { recursive: true })
 await mkdir(runtimeMetadata, { recursive: true })
 await cp(path.join(repositoryRoot, "public"), runtimeAssets, {
   recursive: true,
 })
 await copyFile(
-  path.join(repositoryRoot, "wrangler.toml"),
-  path.join(runtimeRoot, "wrangler.toml"),
-)
-await copyFile(
   path.join(bundleRoot, "index.js"),
-  path.join(runtimeAssets, "_worker.js"),
+  path.join(runtimeWorker, "index.js"),
 )
+
+try {
+  await copyFile(
+    path.join(bundleRoot, "index.js.map"),
+    path.join(runtimeWorker, "index.js.map"),
+  )
+} catch (error) {
+  if (error?.code !== "ENOENT") throw error
+}
+
 await copyFile(
   path.join(bundleRoot, "config.json"),
   path.join(runtimeMetadata, "functions-config.json"),
@@ -60,6 +88,19 @@ await copyFile(
   path.join(bundleRoot, "build-metadata.json"),
   path.join(runtimeMetadata, "build-metadata.json"),
 )
+
+const runtimeConfig = `name = "${projectName}-runtime-contract"
+main = "./worker/index.js"
+compatibility_date = "${compatibilityDate}"
+compatibility_flags = ${compatibilityFlags}
+
+[assets]
+directory = "./public"
+binding = "ASSETS"
+run_worker_first = false
+`
+
+await writeFile(path.join(runtimeRoot, "wrangler.toml"), runtimeConfig)
 
 async function collectFiles(directory) {
   const entries = await readdir(directory, { withFileTypes: true })
@@ -97,7 +138,7 @@ for (const file of stagedFiles) {
 
 const stagedPaths = new Set(manifestFiles.map((file) => file.path))
 assert.ok(stagedPaths.has("public/tailwind.css"), "missing generated CSS")
-assert.ok(stagedPaths.has("public/_worker.js"), "missing prebuilt Worker")
+assert.ok(stagedPaths.has("worker/index.js"), "missing prebuilt Worker")
 assert.ok(
   stagedPaths.has("metadata/functions-config.json"),
   "missing generated Function route metadata",
@@ -106,13 +147,14 @@ assert.ok(
   stagedPaths.has("metadata/build-metadata.json"),
   "missing Worker build metadata",
 )
-assert.ok(stagedPaths.has("wrangler.toml"), "missing Wrangler configuration")
+assert.ok(stagedPaths.has("wrangler.toml"), "missing runtime configuration")
 
 for (const forbiddenPrefix of [
   "app/",
   "build/",
   "functions/",
   "node_modules/",
+  "scripts/",
 ]) {
   assert.equal(
     manifestFiles.some((file) => file.path.startsWith(forbiddenPrefix)),
@@ -121,10 +163,29 @@ for (const forbiddenPrefix of [
   )
 }
 
+for (const forbiddenFile of ["package.json", "yarn.lock"]) {
+  assert.equal(
+    stagedPaths.has(forbiddenFile),
+    false,
+    `runtime stage unexpectedly contains ${forbiddenFile}`,
+  )
+}
+
 const manifest = {
-  schemaVersion: 1,
+  schemaVersion: 2,
   contract:
-    "Static assets and a prebuilt advanced-mode Pages Worker are sufficient for local runtime execution.",
+    "Static assets are served before the prebuilt Pages Worker, and unknown paths execute under workerd without repository source or dependencies.",
+  sourceConfiguration: {
+    projectName,
+    compatibilityDate,
+    compatibilityFlags: JSON.parse(compatibilityFlags.replaceAll("'", '"')),
+  },
+  routing: {
+    assetsDirectory: "public",
+    workerEntry: "worker/index.js",
+    assetsBinding: "ASSETS",
+    runWorkerFirst: false,
+  },
   files: manifestFiles,
   totalBytes: manifestFiles.reduce((total, file) => total + file.bytes, 0),
 }

--- a/scripts/test-cloudflare-runtime.js
+++ b/scripts/test-cloudflare-runtime.js
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict"
 import { spawn } from "node:child_process"
+import { once } from "node:events"
 import { readFile, stat } from "node:fs/promises"
+import { createServer } from "node:net"
 import path from "node:path"
 import { setTimeout as delay } from "node:timers/promises"
 import { fileURLToPath } from "node:url"
@@ -17,16 +19,40 @@ const wranglerExecutable = path.join(
   process.platform === "win32" ? "wrangler.cmd" : "wrangler",
 )
 const host = "127.0.0.1"
-const port = 8788
-const baseUrl = `http://${host}:${port}`
 const analyticsId = "cloudflare-runtime-contract"
 const runtimeLog = []
+
+async function getAvailablePort() {
+  const server = createServer()
+
+  server.unref()
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, host, resolve)
+  })
+
+  const address = server.address()
+
+  assert.ok(address && typeof address === "object")
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()))
+  })
+
+  return address.port
+}
+
+const port = Number(
+  process.env.CLOUDFLARE_RUNTIME_PORT ?? (await getAvailablePort()),
+)
+const baseUrl = `http://${host}:${port}`
 
 for (const requiredPath of [
   wranglerExecutable,
   path.join(runtimeRoot, "manifest.json"),
   path.join(runtimeRoot, "public", "tailwind.css"),
-  path.join(runtimeRoot, "public", "_worker.js"),
+  path.join(runtimeRoot, "worker", "index.js"),
   path.join(runtimeRoot, "wrangler.toml"),
 ]) {
   await stat(requiredPath).catch(() => {
@@ -39,13 +65,28 @@ for (const requiredPath of [
 const manifest = JSON.parse(
   await readFile(path.join(runtimeRoot, "manifest.json"), "utf8"),
 )
-assert.equal(manifest.schemaVersion, 1)
+assert.equal(manifest.schemaVersion, 2)
+assert.ok(manifest.sourceConfiguration.projectName)
+assert.match(manifest.sourceConfiguration.compatibilityDate, /^\d{4}-\d{2}-\d{2}$/)
+assert.ok(
+  manifest.sourceConfiguration.compatibilityFlags.includes("nodejs_compat"),
+)
+assert.equal(manifest.routing.assetsDirectory, "public")
+assert.equal(manifest.routing.workerEntry, "worker/index.js")
+assert.equal(manifest.routing.assetsBinding, "ASSETS")
+assert.equal(manifest.routing.runWorkerFirst, false)
 assert.ok(manifest.files.length > 0)
 assert.equal(
   manifest.files.some((file) =>
-    ["app/", "build/", "functions/", "node_modules/"].some((prefix) =>
-      file.path.startsWith(prefix),
+    ["app/", "build/", "functions/", "node_modules/", "scripts/"].some(
+      (prefix) => file.path.startsWith(prefix),
     ),
+  ),
+  false,
+)
+assert.equal(
+  manifest.files.some((file) =>
+    ["package.json", "yarn.lock"].includes(file.path),
   ),
   false,
 )
@@ -63,21 +104,18 @@ const runtime = spawn(
   [
     "--cwd",
     runtimeRoot,
-    "pages",
     "dev",
-    "public",
+    "--config",
+    "wrangler.toml",
+    "--no-bundle",
     "--ip",
     host,
     "--port",
     String(port),
     "--local-protocol",
     "http",
-    "--binding",
-    `MICRANTHA_ANALYTICS_ID=${analyticsId}`,
-    "--persist-to",
-    ".wrangler-state",
-    "--log-level",
-    "warn",
+    "--var",
+    `MICRANTHA_ANALYTICS_ID:${analyticsId}`,
     "--show-interactive-dev-session=false",
   ],
   {
@@ -87,6 +125,7 @@ const runtime = spawn(
       ...process.env,
       CI: "true",
       NO_COLOR: "1",
+      WRANGLER_SEND_METRICS: "false",
     },
     stdio: ["ignore", "pipe", "pipe"],
   },
@@ -117,19 +156,24 @@ async function stopRuntime() {
     return
   }
 
-  await Promise.race([runtimeExit, delay(3_000)])
+  const stoppedGracefully = await Promise.race([
+    runtimeExit.then(() => true),
+    delay(3_000).then(() => false),
+  ])
 
-  if (runtime.exitCode === null && runtime.signalCode === null) {
-    try {
-      if (process.platform !== "win32" && runtime.pid) {
-        process.kill(-runtime.pid, "SIGKILL")
-      } else {
-        runtime.kill("SIGKILL")
-      }
-    } catch {
-      return
+  if (stoppedGracefully || runtime.exitCode !== null) return
+
+  try {
+    if (process.platform !== "win32" && runtime.pid) {
+      process.kill(-runtime.pid, "SIGKILL")
+    } else {
+      runtime.kill("SIGKILL")
     }
+  } catch {
+    return
   }
+
+  await runtimeExit
 }
 
 async function fetchRuntime(pathname, options = {}) {
@@ -141,7 +185,8 @@ async function fetchRuntime(pathname, options = {}) {
 }
 
 async function waitForRuntime() {
-  const deadline = Date.now() + 30_000
+  const startedAt = Date.now()
+  const deadline = startedAt + 30_000
 
   while (Date.now() < deadline) {
     if (runtime.exitCode !== null || runtime.signalCode !== null) {
@@ -153,7 +198,10 @@ async function waitForRuntime() {
 
     try {
       const response = await fetchRuntime("/")
-      if (response.status === 200) return
+
+      await response.body?.cancel()
+
+      if (response.status === 200) return Date.now() - startedAt
     } catch {
       // The local socket is not ready yet.
     }
@@ -201,7 +249,7 @@ function assertDocumentHeaders(response, body, { requireNonce = true } = {}) {
 }
 
 try {
-  await waitForRuntime()
+  const readyMilliseconds = await waitForRuntime()
 
   const home = await readRuntime("/")
   assert.equal(home.response.status, 200)
@@ -216,6 +264,11 @@ try {
   assert.match(css.response.headers.get("content-type") ?? "", /^text\/css\b/)
   assert.ok(css.body.length > 1_000, "expected generated Tailwind CSS")
 
+  const manifestResponse = await fetchRuntime("/icon/site.webmanifest")
+  assert.equal(manifestResponse.status, 200)
+  const siteManifest = await manifestResponse.json()
+  assert.equal(siteManifest.name, "Micrantha Software")
+
   const browserAssetPath = home.body.match(
     /(?:src|href)="([^"?#]*\/build\/[^"?#]+\.js)"/,
   )?.[1]
@@ -229,23 +282,21 @@ try {
   )
   assert.ok(browserAsset.body.length > 1_000, "expected a browser bundle")
 
-  const article = await readRuntime(
-    "/blog/ai-pipelines-need-control-boundaries",
-  )
+  const articlePath = "/blog/ai-pipelines-need-control-boundaries"
+  const article = await readRuntime(articlePath)
   assert.equal(article.response.status, 200)
   assert.match(article.body, /AI Pipelines Need Control Boundaries/)
   assert.match(
     article.body,
     /AI is not the system of record\. AI is an untrusted reasoning component/,
   )
+  assert.match(article.body, new RegExp(`https://micrantha.com${articlePath}`))
+  assert.match(article.body, /"@type":"Article"/)
   assertDocumentHeaders(article.response, article.body)
 
-  const botArticle = await readRuntime(
-    "/blog/ai-pipelines-need-control-boundaries",
-    {
-      headers: { "User-Agent": "Googlebot/2.1" },
-    },
-  )
+  const botArticle = await readRuntime(articlePath, {
+    headers: { "User-Agent": "Googlebot/2.1" },
+  })
   assert.equal(botArticle.response.status, 200)
   assert.match(botArticle.body, /AI Pipelines Need Control Boundaries/)
   assertDocumentHeaders(botArticle.response, botArticle.body)
@@ -255,7 +306,9 @@ try {
   assert.match(missing.body, /404|Not Found/i)
   assertDocumentHeaders(missing.response, missing.body, { requireNonce: false })
 
-  console.log("Cloudflare Pages runtime contract passed")
+  console.log(
+    `Cloudflare runtime contract passed; local workerd ready in ${readyMilliseconds} ms`,
+  )
 } catch (error) {
   error.message += formattedRuntimeLog()
   throw error


### PR DESCRIPTION
## Duplicate of #83

PR #83 contains the same current-main asset-routing correction with the same four-file scope, while avoiding the unused `once` import present on this branch and documenting the relationship to `public/_routes.json` explicitly.

Closing this duplicate prevents parallel CI and conflicting merges. No unique work is discarded.