### PR TITLE
Add redirect and controlled-error Cloudflare contracts

### DIFF
--- a/app/routes/contact.tsx
+++ b/app/routes/contact.tsx
@@ -1,0 +1,7 @@
+import { redirect } from "@remix-run/node"
+
+export const loader = () => redirect("/services", 301)
+
+export default function ContactRedirect() {
+  return null
+}

--- a/scripts/test-cloudflare-adapter.js
+++ b/scripts/test-cloudflare-adapter.js
@@ -7,8 +7,12 @@ const { onRequest } = await import("../functions/[[path]].js")
 const origin = "https://micrantha.example"
 const analyticsId = "adapter-contract-test"
 
-async function request(pathname, { userAgent = "adapter-contract" } = {}) {
+async function request(
+  pathname,
+  { userAgent = "adapter-contract", method = "GET" } = {},
+) {
   const request = new Request(new URL(pathname, origin), {
+    method,
     headers: {
       "User-Agent": userAgent,
     },
@@ -77,6 +81,11 @@ assert.match(home.body, /id="content"/)
 assert.match(home.body, new RegExp(`data-website-id="${analyticsId}"`))
 assertDocumentHeaders(home.response, home.body)
 
+const contactRedirect = await read("/contact")
+assert.equal(contactRedirect.response.status, 301)
+assert.equal(contactRedirect.response.headers.get("location"), "/services")
+assert.equal(contactRedirect.body, "")
+
 const article = await read("/blog/ai-pipelines-need-control-boundaries")
 assert.equal(article.response.status, 200)
 assert.match(article.body, /AI Pipelines Need Control Boundaries/)
@@ -92,6 +101,13 @@ const botArticle = await read("/blog/ai-pipelines-need-control-boundaries", {
 assert.equal(botArticle.response.status, 200)
 assert.match(botArticle.body, /AI Pipelines Need Control Boundaries/)
 assertDocumentHeaders(botArticle.response, botArticle.body)
+
+const methodNotAllowed = await read("/services", { method: "POST" })
+assert.equal(methodNotAllowed.response.status, 405)
+assert.match(methodNotAllowed.body, /405|Method Not Allowed/i)
+assertDocumentHeaders(methodNotAllowed.response, methodNotAllowed.body, {
+  requireNonce: false,
+})
 
 const missing = await read("/this-route-does-not-exist")
 assert.equal(missing.response.status, 404)

--- a/scripts/test-cloudflare-runtime.js
+++ b/scripts/test-cloudflare-runtime.js
@@ -261,6 +261,11 @@ try {
   assert.match(home.body, /https:\/\/micrantha\.com/)
   assertDocumentHeaders(home.response, home.body)
 
+  const contactRedirect = await readRuntime("/contact")
+  assert.equal(contactRedirect.response.status, 301)
+  assert.equal(contactRedirect.response.headers.get("location"), "/services")
+  assert.equal(contactRedirect.body, "")
+
   const css = await readRuntime("/tailwind.css")
   assert.equal(css.response.status, 200)
   assert.match(css.response.headers.get("content-type") ?? "", /^text\/css\b/)
@@ -302,6 +307,13 @@ try {
   assert.equal(botArticle.response.status, 200)
   assert.match(botArticle.body, /AI Pipelines Need Control Boundaries/)
   assertDocumentHeaders(botArticle.response, botArticle.body)
+
+  const methodNotAllowed = await readRuntime("/services", { method: "POST" })
+  assert.equal(methodNotAllowed.response.status, 405)
+  assert.match(methodNotAllowed.body, /405|Method Not Allowed/i)
+  assertDocumentHeaders(methodNotAllowed.response, methodNotAllowed.body, {
+    requireNonce: false,
+  })
 
   const missing = await readRuntime("/this-route-does-not-exist")
   assert.equal(missing.response.status, 404)


### PR DESCRIPTION
## Summary

- preserve the legacy `/contact` URL with a permanent 301 redirect to `/services`
- verify redirect status and relative `Location` through the direct Pages adapter contract
- verify the same redirect through the source-isolated asset-first workerd runtime
- exercise `POST /services` as a framework-controlled 405 response through both execution paths
- verify the controlled error document retains invariant production security and cache headers

## Design

The redirect is a normal Remix route, not a Cloudflare-only rule, so application behavior remains consistent across local Node, the direct Pages adapter, and workerd.

The controlled-error fixture uses an unsupported method on an existing loader-only public route. Remix generates the 405 response naturally; no test-only public route, secret header, or environment switch is added.

## Contract coverage

Both Cloudflare contracts now cover:

- successful SSR
- permanent redirect
- nested content and bot rendering
- controlled 405 method error
- 404 handling
- successful-document CSP nonce pairing
- cache and invariant security headers

The runtime contract continues to run against the source-isolated, asset-first Worker stage merged in #83.

## Scope

Progresses #56. Dashboard/configuration parity, production startup measurement, and deeper deployed CDN/cache validation remain operational follow-up work. MDX-specific no-JavaScript coverage remains in #55.