### PR TITLE
Close the Cloudflare Pages production contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Typecheck
         run: yarn typecheck
 
+      - name: Verify Cloudflare Pages configuration
+        run: yarn test:cloudflare:config
+
       - name: Build
         run: yarn build
 
@@ -88,12 +91,14 @@ jobs:
       - name: Test Cloudflare Pages runtime contract
         run: yarn test:cloudflare:runtime
 
-      - name: Upload Cloudflare runtime manifest
+      - name: Upload Cloudflare runtime evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: cloudflare-pages-runtime-${{ github.run_id }}
-          path: .cloudflare/runtime/manifest.json
+          path: |
+            .cloudflare/runtime/manifest.json
+            .cloudflare/runtime/runtime-report.json
           if-no-files-found: ignore
           retention-days: 7
 

--- a/README.md
+++ b/README.md
@@ -51,13 +51,14 @@ Open `http://localhost:3000`.
 | `yarn dev`                           | Run Remix and Tailwind in watch mode                           |
 | `yarn build`                         | Build CSS and Remix for production                             |
 | `yarn cloudflare:functions:build`    | Bundle the Pages Function with pinned Wrangler                 |
-| `yarn cloudflare:runtime:stage`      | Stage only the deployable Pages assets and prebuilt Worker     |
+| `yarn cloudflare:runtime:stage`      | Stage only deployable Pages assets and the generated Worker    |
 | `yarn start`                         | Serve the production build locally through `remix-serve`       |
 | `yarn lint`                          | Run ESLint                                                     |
 | `yarn lint:fix`                      | Auto-fix lint issues                                           |
 | `yarn typecheck`                     | Run the TypeScript build check                                 |
 | `yarn test:cloudflare:adapter`       | Exercise the built Pages Function entry directly               |
 | `yarn test:cloudflare:bundle-budget` | Enforce raw and gzip Worker size budgets                       |
+| `yarn test:cloudflare:config`        | Verify Wrangler, deploy-script, and configuration parity       |
 | `yarn test:cloudflare:runtime`       | Exercise the staged Worker through the local Pages runtime     |
 | `yarn test:e2e`                      | Run the full Playwright suite                                  |
 | `yarn test:e2e:mobile`               | Run the mobile Playwright project only                         |
@@ -85,11 +86,12 @@ yarn build
 yarn test:cloudflare:adapter
 ```
 
-This imports the checked-in Pages Function entry against the generated Remix server build and verifies representative SSR, binding, status, CSP nonce, cache, and security-header behavior. It is a fast adapter-level diagnostic, not a Workers-runtime substitute.
+This imports the checked-in Pages Function entry against the generated Remix server build and verifies representative SSR, binding, exact cache policies, canonical and JSON-LD metadata, redirects, 404/405 status behavior, CSP nonce pairing, and security headers. It is a fast adapter-level diagnostic, not a Workers-runtime substitute.
 
-Bundle the Pages Function using the repository-pinned Wrangler version, enforce its size budgets, then run the authoritative local runtime contract:
+Validate the checked-in Cloudflare configuration, bundle the Pages Function using the repository-pinned Wrangler version, enforce its size budgets, then run the authoritative local runtime contract:
 
 ```sh
+yarn test:cloudflare:config
 yarn build
 yarn cloudflare:functions:build
 yarn test:cloudflare:bundle-budget
@@ -103,13 +105,25 @@ The runtime test creates an ignored `.cloudflare/runtime/` stage containing only
 - generated Worker route and build metadata;
 - `wrangler.toml`.
 
-It deliberately excludes `app/`, `build/`, `functions/`, and `node_modules/` from the staged runtime payload. Wrangler consumes that source-free stage through Pages advanced mode, performs the final compatibility-aware bundle required by the Worker’s `nodejs_compat` imports, and starts workerd with `pages dev public`. The contract then verifies SSR, nested and bot routes, 404 behavior, CSP nonce pairing, cache and security headers, static CSS, and a generated browser bundle.
+It deliberately excludes `app/`, `build/`, `functions/`, and `node_modules/` from the staged runtime payload. Wrangler consumes that source-free stage through Pages advanced mode, performs the final compatibility-aware bundle required by the Worker’s `nodejs_compat` imports, and starts workerd with `pages dev public`.
+
+The workerd contract verifies:
+
+- complete SSR for home, nested article, and bot requests;
+- exact application cache policies;
+- CSP nonce/header pairing and security headers;
+- canonical URL and Article JSON-LD output;
+- the permanent `/contact` to `/services` redirect;
+- 404 and controlled 405 error documents;
+- static CSS and a generated browser bundle;
+- Pages binding propagation;
+- local Pages readiness against `config/cloudflare-runtime-budget.json`.
 
 `config/cloudflare-bundle-budget.json` records the current raw and gzip baselines, selected platform envelope, and enforced repository budgets. The budget command writes `.cloudflare/functions/bundle-budget.json` with actual sizes and baseline deltas; required CI uploads it with the generated Function bundle.
 
-The generated function bundle, config, build metadata, budget report, and runtime manifest are written under the ignored `.cloudflare/` directory. Required CI uploads those outputs for inspection. Required jobs use clean frozen installs instead of setup-node’s Yarn cache because the Wrangler dependency graph produced approximately 1.9 GB cache archives; the lockfile remains the reproducibility control.
+`config/cloudflare-pages-contract.json` records the repository-visible Pages configuration. `yarn test:cloudflare:config` rejects drift from `wrangler.toml`, the deploy script, and the expected Function entry. Dashboard-only parity and post-deploy CDN checks are documented in [Cloudflare Pages Configuration Parity](docs/operations/cloudflare-pages-configuration.md).
 
-Issue #56 retains explicit redirect and controlled-error coverage, dashboard/configuration parity, production startup measurement, and deeper CDN/cache validation.
+The generated function bundle, config, build metadata, budget report, runtime manifest, and runtime startup report are written under the ignored `.cloudflare/` directory. Required CI uploads those outputs for inspection. Required jobs use clean frozen installs instead of setup-node’s Yarn cache because the Wrangler dependency graph produced approximately 1.9 GB cache archives; the lockfile remains the reproducibility control.
 
 Run a specific spec:
 
@@ -148,7 +162,9 @@ Checked-in config:
 - `wrangler.toml`
 - `functions/[[path]].js`
 - `config/cloudflare-bundle-budget.json`
-- `package.json` deploy, bundle, budget, and runtime-test scripts
+- `config/cloudflare-pages-contract.json`
+- `config/cloudflare-runtime-budget.json`
+- `package.json` deploy, bundle, budget, config, and runtime-test scripts
 - lockfile-pinned Wrangler dependency
 
 Expected environment variables:
@@ -163,7 +179,7 @@ Deploy manually:
 yarn deploy:cloudflare
 ```
 
-The deployment command runs typechecking, the application build, Pages Function bundling, bundle-budget enforcement, the direct adapter contract, and the staged Pages runtime contract before invoking the pinned Wrangler binary.
+The deployment command runs typechecking, configuration validation, the application build, Pages Function bundling, bundle-budget enforcement, the direct adapter contract, and the staged Pages runtime contract before invoking the pinned Wrangler binary.
 
 ## Docker
 
@@ -187,13 +203,13 @@ make run
 
 ```text
 app/          Remix routes, components, services, and utilities
-config/       Enforced runtime and bundle policy
+config/       Enforced deployment, runtime, and bundle policy
 docs/         Architecture and operational decisions
 e2e/          Playwright specs and visual baselines
 public/       Static assets and browser build output
 build/        Remix server build produced by yarn build
 functions/    Cloudflare Pages Functions request adapter
-scripts/      Build, staging, and runtime-contract automation
+scripts/      Build, staging, policy, and runtime-contract automation
 ```
 
 ## Development Notes

--- a/app/routes/contact.tsx
+++ b/app/routes/contact.tsx
@@ -1,0 +1,7 @@
+import { redirect } from "@remix-run/node"
+
+export const loader = () => redirect("/services", 301)
+
+export default function ContactRedirect() {
+  return null
+}

--- a/config/cloudflare-pages-contract.json
+++ b/config/cloudflare-pages-contract.json
@@ -1,0 +1,14 @@
+{
+  "projectName": "micrantha-web",
+  "pagesBuildOutputDirectory": "./public",
+  "compatibilityDate": "2026-03-21",
+  "compatibilityFlags": ["nodejs_compat"],
+  "uploadSourceMaps": true,
+  "bindings": [
+    {
+      "name": "MICRANTHA_ANALYTICS_ID",
+      "required": false,
+      "sensitive": false
+    }
+  ]
+}

--- a/config/cloudflare-runtime-budget.json
+++ b/config/cloudflare-runtime-budget.json
@@ -1,0 +1,4 @@
+{
+  "localPagesReadyMilliseconds": 10000,
+  "description": "Maximum CI time from starting pinned Wrangler to the first successful SSR response. This is a local regression budget, not Cloudflare production CPU startup time."
+}

--- a/docs/architecture/cloudflare-pages-ssr.md
+++ b/docs/architecture/cloudflare-pages-ssr.md
@@ -1,6 +1,6 @@
 # Cloudflare Pages SSR Architecture
 
-- **Status:** Accepted baseline
+- **Status:** Accepted and implemented baseline
 - **Date:** 2026-08-03
 - **Issue:** #56
 - **Decision scope:** Production runtime, deployment artifacts, compatibility boundaries, and validation responsibilities
@@ -9,7 +9,7 @@
 
 Micrantha Web is a server-rendered Remix 2 application deployed to Cloudflare Pages. The repository also supports local Node serving through `remix-serve`, a Docker image, and Makefile wrappers. Those paths are useful for development and portability, but they do not execute the same adapter or runtime used by production.
 
-The production path is currently defined by:
+The production path is defined by:
 
 - `wrangler.toml`, including `pages_build_output_dir`, compatibility date, and `nodejs_compat`;
 - `functions/[[path]].js`, which creates the Remix request handler;
@@ -17,20 +17,25 @@ The production path is currently defined by:
 - `public/`, containing static assets and the browser build;
 - Cloudflare Pages Functions, which bundles the root `functions/` directory into a Worker.
 
-Current browser tests start `remix-serve`. That validates the Remix application and production build, but it does not prove that the Pages Function bundles, starts, preserves headers, or behaves correctly under the Workers runtime.
+Application-level browser tests start `remix-serve`. Separate configuration, bundle, adapter, and workerd contracts prove that the Pages Function can be built, staged, started, and exercised through the Workers runtime.
 
 ## Decision
 
 Cloudflare Pages Functions is the authoritative production runtime.
 
-The repository must treat the following pipeline as the production contract:
+The repository treats the following pipeline as the production contract:
 
 ```text
 source
   -> locked dependency install
+  -> checked-in Pages configuration contract
   -> Tailwind CSS build
   -> Remix browser and server build
   -> Pages Functions bundle
+  -> raw and gzip Worker budgets
+  -> source-isolated advanced-mode Pages stage
+  -> pinned Wrangler compatibility-aware final bundle
+  -> workerd startup and HTTP contract
   -> public static assets plus Worker artifact
   -> Cloudflare Pages request
   -> functions/[[path]].js
@@ -38,43 +43,54 @@ source
   -> streamed response
 ```
 
-A change is production-compatible only when it passes the Pages Functions build and runtime contract. Passing through `remix-serve`, the Remix development server, or Docker alone is insufficient.
+A change is production-compatible only when it passes the Pages configuration, bundle budget, adapter, workerd runtime, and existing browser contracts. Passing through `remix-serve`, the Remix development server, or Docker alone is insufficient.
 
 ## Source of truth
 
 ### Repository configuration
 
-`wrangler.toml` is the repository source of truth for:
+`wrangler.toml` is the deployment source of truth for:
 
-- the Pages project name used by local and scripted operations;
-- the static output directory;
-- the Workers compatibility date;
+- Pages project name;
+- static output directory;
+- Workers compatibility date;
 - compatibility flags;
 - source-map upload behavior.
 
-Cloudflare dashboard configuration must not silently diverge from the checked-in file. Operational documentation must identify any dashboard-only bindings or secrets and describe how parity is reviewed.
+`config/cloudflare-pages-contract.json` provides a machine-readable projection of those values plus the documented binding inventory. `yarn test:cloudflare:config` rejects drift between the contract, `wrangler.toml`, the default deployment command, and the expected Function entry.
+
+Dashboard-only values and the required post-deploy parity review are documented in `docs/operations/cloudflare-pages-configuration.md`. Secrets are never committed or emitted in CI artifacts.
 
 ### Production entry point
 
 `functions/[[path]].js` is the production request adapter. It imports the generated Remix server build and translates the Pages Function context into a Remix request.
 
-The adapter must depend only on declared packages and generated deployment artifacts. It must not rely on transitive dependency hoisting, TypeScript source, content source files, or compiler packages at request time.
+`@remix-run/server-runtime` is a direct dependency because the repository intentionally owns that request-handler boundary. The adapter does not rely on transitive package hoisting.
 
-### Build artifacts
+### Build and runtime artifacts
 
-The production deployment consists of:
+The deployment consists of:
 
 - `public/` for static assets and browser output;
 - the bundled Pages Function generated from `functions/`;
-- the generated Remix server build consumed by that Function during bundling.
+- the generated Remix server build consumed during Function bundling.
 
-Source `.tsx`, `.md`, and `.mdx` files are build inputs, not runtime dependencies.
+The runtime contract creates `.cloudflare/runtime/` containing only:
+
+- the static `public/` tree;
+- the generated Worker as advanced-mode `public/_worker.js`;
+- generated Worker route and build metadata;
+- `wrangler.toml`.
+
+The stage manifest records each file's byte size and SHA-256 digest. It rejects `app/`, `build/`, `functions/`, and `node_modules/` paths. Source `.tsx`, `.md`, and `.mdx` files are build inputs, not runtime dependencies.
 
 ## Runtime compatibility boundary
 
 `nodejs_compat` is permitted only for APIs required by the current Remix server build or adapter. New Node-specific runtime dependencies require explicit review.
 
-The application should prefer Web Platform APIs available in both Workers and modern Node runtimes:
+The intermediate Worker produced by `wrangler pages functions build` preserves Node built-in imports such as `crypto`, `stream`, `util`, and `string_decoder`. Pinned Wrangler therefore performs the final compatibility-aware bundle before workerd starts. Running that intermediate artifact with `--no-bundle` is not supported.
+
+Application request handling should prefer Web Platform APIs:
 
 - `Request` and `Response`;
 - `Headers`;
@@ -84,57 +100,64 @@ The application should prefer Web Platform APIs available in both Workers and mo
 
 Direct filesystem access, child processes, native addons, and assumptions about a writable local filesystem are prohibited in request handling.
 
-The compatibility date is an operational API version. Updating it is a production change and must pass the Pages adapter suite before merge.
+The compatibility date is an operational API version. Updating it is a production change and must pass the complete Cloudflare contract before merge.
 
 ## Request and response contract
-
-The Pages runtime must preserve the following externally observable behavior:
 
 ### Rendering
 
 - direct requests return meaningful server-rendered HTML;
 - normal browser requests may stream;
 - bot requests may wait for the full stream according to `app/entry.server.tsx`;
-- primary content must not require hydration unless a feature explicitly documents that trade-off.
+- primary content remains usable without hydration unless a feature explicitly documents another contract.
 
 ### Status and routing
 
 - successful routes preserve their intended status;
 - unknown routes return 404;
-- redirects preserve status and `Location`;
-- controlled server failures return the intended error document and status.
+- the legacy `/contact` URL permanently redirects to `/services` with status 301;
+- unsupported `POST /services` requests return a controlled 405 error document;
+- redirect and error behavior are exercised through both the direct adapter and workerd.
 
-### Headers
+### Headers and metadata
 
-- document cache policy is preserved through the adapter;
-- CSP nonces in headers and HTML remain paired;
+- exact application `Cache-Control` policies survive the adapter;
+- CSP header nonces match nonced scripts in the document;
 - security headers apply to successful and error documents;
-- content type and canonical metadata remain correct.
+- article canonical URLs and Article JSON-LD survive the production path;
+- content type remains correct.
 
 ### Assets
 
 - generated Tailwind CSS resolves from `public/`;
-- browser bundles, icons, images, sitemap, and manifest assets resolve through Pages;
+- a generated browser bundle resolves from the staged artifact;
+- icons, images, sitemap, and manifest remain deployment assets;
 - source maps are uploaded only through the documented deployment path.
 
 ## Cache ownership
 
-Application code defines response cache policy. Cloudflare may enforce or transform caching only through documented platform configuration.
+Application code defines response cache policy. The baseline workerd and direct-adapter contracts assert:
 
-The adapter suite must verify representative `Cache-Control` behavior. Future authenticated, preview, draft, or user-specific routes must default to non-shared caching until explicitly classified.
+- home: `public, max-age=60, s-maxage=300, stale-while-revalidate=900`;
+- representative article: `public, max-age=60, s-maxage=300, stale-while-revalidate=600`.
 
-Per-response CSP nonces require the HTML document and CSP header to remain one cache object. Tests must detect header/body recombination or policy loss.
+Cloudflare dashboard cache rules must not silently override application semantics. Production CDN behavior is reviewed through the documented post-deploy smoke check because local workerd cannot reproduce the full Cloudflare edge cache.
+
+Future authenticated, preview, draft, or user-specific routes default to non-shared caching until explicitly classified.
 
 ## Environment and analytics
 
 Runtime configuration is resolved through the Pages Function context and request environment. Secrets and bindings are not committed.
 
-The analytics identifier is optional. Missing analytics configuration must not prevent rendering. Adding a new runtime binding requires documentation of:
+`MICRANTHA_ANALYTICS_ID` is optional and non-sensitive. Missing analytics configuration must not prevent rendering. The runtime contract injects a test binding and verifies that it reaches the rendered document.
 
-- its owner;
+New runtime bindings require documentation of:
+
+- owner;
 - preview and production behavior;
 - failure behavior;
-- security and privacy implications.
+- security and privacy implications;
+- whether the binding is sensitive.
 
 ## Supported execution paths
 
@@ -142,7 +165,13 @@ The analytics identifier is optional. Missing analytics configuration must not p
 
 **Role:** Authoritative production runtime and deployment contract.
 
-Must be exercised by CI through a pinned Wrangler build and local Pages runtime harness.
+Required CI builds with pinned Wrangler, enforces bundle budgets, stages a source-isolated advanced-mode Worker, and executes it under workerd.
+
+### Direct adapter contract
+
+**Role:** Fast request-adapter diagnostic.
+
+It imports `functions/[[path]].js` against the generated Remix build and verifies representative SSR, binding, cache, metadata, status, redirect, error, nonce, and security-header behavior. It does not substitute for workerd.
 
 ### `remix-serve`
 
@@ -160,7 +189,7 @@ Development-only CSP allowances and WebSocket behavior must not leak into produc
 
 **Role:** Local Node portability and optional deployment-parity experiment.
 
-The current image runs `remix-serve`; it is not the Cloudflare production artifact. Docker documentation must state that distinction. If the image is retained as an operational artifact, it requires its own dependency and vulnerability policy.
+The image runs `remix-serve`; it is not the Cloudflare production artifact. Docker requires its own dependency and vulnerability policy if retained as an operational artifact.
 
 ### Makefile
 
@@ -170,53 +199,69 @@ Package scripts and checked-in platform configuration remain authoritative. Make
 
 ## Toolchain requirements
 
-Wrangler must be declared and lockfile-controlled. Production compatibility checks and deployment scripts must not fetch an unspecified Wrangler version through `npx`.
+Wrangler is declared and lockfile-controlled. Production checks and deployment scripts do not fetch an unspecified Wrangler version through `npx`.
 
-The Pages Function adapter must use a direct, intentional dependency. The implementation must decide whether to:
-
-1. declare `@remix-run/server-runtime` directly; or
-2. use a public Cloudflare/Remix adapter package that owns the request-handler boundary.
-
-Relying on a transitive package being hoisted is not acceptable.
+Required CI uses clean frozen installs rather than setup-node's Yarn cache because the Wrangler dependency graph produced approximately 1.9 GB cache archives. The lockfile remains the reproducibility control.
 
 ## CI contract
 
-The required Pages adapter job will:
+The required Quality job:
 
-1. install dependencies with the frozen lockfile;
-2. build CSS and Remix production artifacts;
-3. bundle Pages Functions with the pinned Wrangler version and checked-in configuration;
-4. record Worker bundle metadata and size;
-5. start the bundled application with `wrangler pages dev` or an equivalent Workers-runtime harness;
-6. run HTTP contract tests against that runtime;
-7. fail on unresolved imports, unsupported runtime APIs, missing assets, incorrect statuses, or header regressions.
+1. installs dependencies with the frozen lockfile;
+2. validates formatting, lint, and types;
+3. verifies the checked-in Pages configuration contract;
+4. builds CSS and Remix production artifacts;
+5. verifies the pinned Wrangler version;
+6. bundles the Pages Function;
+7. enforces raw and gzip Worker budgets;
+8. uploads bundle metadata and budget evidence;
+9. runs the direct adapter contract;
+10. stages the source-isolated Pages runtime;
+11. performs the final compatibility-aware bundle and starts workerd;
+12. enforces the local readiness budget;
+13. runs HTTP contracts against workerd;
+14. uploads the runtime manifest and startup report.
 
-The baseline suite must cover:
+The baseline suite covers:
 
-- `/`;
-- one representative nested route;
+- `/` SSR;
+- a representative nested article;
 - a bot request;
+- exact home and article cache policies;
+- article canonical metadata and JSON-LD;
 - a 404;
-- a controlled error route or test fixture;
-- a redirect;
+- controlled 405 behavior;
+- the `/contact` redirect;
 - CSP nonce/header pairing;
-- cache headers;
-- static CSS and asset resolution;
-- canonical metadata and JSON-LD.
+- security headers;
+- static CSS and browser asset resolution;
+- Pages binding propagation;
+- source-isolated execution.
 
-The harness should run from a staged deployment context where practical, proving that source files and build-only packages are unnecessary at request time.
+Issue #55 extends this harness with MDX-specific and JavaScript-disabled article tests without reopening the production topology.
 
-Issue #55 will extend this established harness with MDX-specific and JavaScript-disabled article tests. Those extension tests are not part of the baseline closure criteria for #56.
+## Bundle and startup budgets
 
-## Bundle budget
+`config/cloudflare-bundle-budget.json` records:
 
-The first implementation slice must record the current compressed and uncompressed Worker size. The enforced limit should preserve explicit headroom below the applicable Cloudflare plan limit.
+- Wrangler version and measured baseline;
+- Workers Free compressed and uncompressed platform envelope;
+- enforced repository raw and gzip budgets.
 
-Subsequent architectural changes must report their delta. Browser route splitting does not guarantee equivalent Worker splitting, so server bundle growth must be measured independently.
+The repository budgets are intentionally stricter than the platform ceiling:
+
+| Measurement | Baseline | Repository budget | Platform envelope |
+| --- | ---: | ---: | ---: |
+| Raw Worker | 2,356,613 B | 3,000,000 B | 64,000,000 B |
+| Gzip Worker | 466,338 B | 2,500,000 B | 3,000,000 B |
+
+The generated `.cloudflare/functions/bundle-budget.json` records actual sizes and deltas from the baseline.
+
+`config/cloudflare-runtime-budget.json` sets a 10,000 ms local Pages readiness budget from starting pinned Wrangler to the first successful SSR response. This is a CI regression signal that includes local compatibility bundling and workerd startup; it is not a claim about Cloudflare production CPU startup time. The generated `.cloudflare/runtime/runtime-report.json` records the measurement and headroom.
 
 ## Security considerations
 
-The production adapter is part of the trust boundary. Review must include:
+The production adapter is part of the trust boundary. Review includes:
 
 - declared dependency provenance;
 - compatibility flags;
@@ -225,33 +270,37 @@ The production adapter is part of the trust boundary. Review must include:
 - error-path header behavior;
 - source-map handling;
 - accidental inclusion of source content or build-time tooling;
-- cache behavior for any future non-public route.
+- cache behavior for future non-public routes;
+- bundle growth that could force an unplanned platform change.
 
-Detailed CSP and cross-origin policy hardening remains owned by #57, but the baseline adapter tests must prove that current headers survive production execution.
+Detailed CSP and cross-origin hardening remains owned by #57, while the baseline contract proves that current headers survive production execution.
 
 ## Consequences
 
 ### Positive
 
-- Cloudflare compatibility becomes measurable rather than assumed.
-- MDX and framework migrations gain a stable production acceptance boundary.
-- Runtime-only and build-only dependencies become distinguishable.
-- deployment documentation, scripts, and CI converge on one topology.
-- Worker growth and compatibility-date changes become reviewable.
+- Cloudflare compatibility is measured rather than assumed.
+- MDX and framework migrations have a stable production acceptance boundary.
+- Runtime-only and build-only dependencies are distinguishable.
+- Deployment documentation, scripts, and CI converge on one topology.
+- Worker size and startup regressions are visible.
+- Redirect, error, cache, canonical, and JSON-LD behavior cannot silently diverge between Node and workerd.
+- Dashboard-only configuration has an explicit parity and post-deploy review process.
 
 ### Costs
 
-- CI gains another build/runtime path in addition to browser tests.
-- Wrangler becomes a repository-managed dependency.
-- some Node-oriented dependencies may require replacement or explicit compatibility justification.
-- maintaining both Docker and Cloudflare paths requires clear scope to prevent false parity claims.
+- CI maintains an additional runtime path beyond browser tests.
+- Wrangler is a repository-managed dependency.
+- Node-oriented dependencies may require replacement or explicit compatibility justification.
+- Local startup measurement is environment-sensitive and therefore uses a conservative regression budget.
+- Maintaining both Docker and Cloudflare paths requires clear scope to prevent false parity claims.
 
-## Follow-up implementation
+## Extension rules
 
-1. Pin Wrangler and replace unpinned invocations.
-2. resolve the direct Remix runtime dependency decision;
-3. add Pages Function bundle and runtime scripts;
-4. record the Worker bundle baseline and budget;
-5. add the Cloudflare adapter CI job and HTTP contract suite;
-6. align README, Docker, Makefile, and package script descriptions;
-7. extend the harness from #55, #57, and #58 without redefining the production topology.
+Future work from #55, #57, #58, or framework modernization may extend the contract, but must not:
+
+- make `remix-serve` the production authority;
+- bypass configuration or bundle budgets;
+- remove source-isolation guarantees;
+- introduce unpinned runtime tooling;
+- weaken no-JavaScript content, cache, metadata, or security-header coverage.

--- a/docs/architecture/cloudflare-pages-ssr.md
+++ b/docs/architecture/cloudflare-pages-ssr.md
@@ -250,10 +250,10 @@ Issue #55 extends this harness with MDX-specific and JavaScript-disabled article
 
 The repository budgets are intentionally stricter than the platform ceiling:
 
-| Measurement | Baseline | Repository budget | Platform envelope |
-| --- | ---: | ---: | ---: |
-| Raw Worker | 2,356,613 B | 3,000,000 B | 64,000,000 B |
-| Gzip Worker | 466,338 B | 2,500,000 B | 3,000,000 B |
+| Measurement |    Baseline | Repository budget | Platform envelope |
+| ----------- | ----------: | ----------------: | ----------------: |
+| Raw Worker  | 2,356,613 B |       3,000,000 B |      64,000,000 B |
+| Gzip Worker |   466,338 B |       2,500,000 B |       3,000,000 B |
 
 The generated `.cloudflare/functions/bundle-budget.json` records actual sizes and deltas from the baseline.
 

--- a/docs/operations/cloudflare-pages-configuration.md
+++ b/docs/operations/cloudflare-pages-configuration.md
@@ -1,0 +1,87 @@
+# Cloudflare Pages Configuration Parity
+
+## Authority
+
+`wrangler.toml` and `config/cloudflare-pages-contract.json` are the repository source of truth for the deployable Pages configuration.
+
+Required CI runs `yarn test:cloudflare:config` to reject drift between:
+
+- Pages project name;
+- static output directory;
+- compatibility date;
+- compatibility flags;
+- source-map behavior;
+- the default project and output arguments in `deploy:cloudflare`;
+- the expected Pages Function entry.
+
+## Contracted values
+
+| Setting | Required value |
+| --- | --- |
+| Pages project | `micrantha-web` |
+| Build output directory | `./public` |
+| Compatibility date | `2026-03-21` |
+| Compatibility flags | `nodejs_compat` |
+| Upload source maps | enabled |
+| Pages Function entry | `functions/[[path]].js` |
+
+## Dashboard-only configuration
+
+The Cloudflare API token and any sensitive bindings remain outside the repository.
+
+`MICRANTHA_ANALYTICS_ID` is an optional, non-sensitive runtime binding. Missing analytics configuration must not block rendering.
+
+Any new dashboard-only value must be added to `config/cloudflare-pages-contract.json` with:
+
+- its binding name;
+- whether it is required;
+- whether it is sensitive;
+- its preview and production ownership;
+- its expected failure behavior.
+
+Secrets must never be committed or emitted in CI artifacts.
+
+## Parity review
+
+Review dashboard parity when:
+
+- `wrangler.toml` changes;
+- Wrangler is upgraded;
+- a binding is added, removed, or renamed;
+- the Pages project or branch strategy changes;
+- a production deployment behaves differently from workerd.
+
+The reviewer must compare the Cloudflare Pages project settings with the contracted values above and confirm:
+
+1. the production project is `micrantha-web`;
+2. the compatibility date is `2026-03-21`;
+3. `nodejs_compat` is enabled;
+4. the build output directory is `public`;
+5. source-map upload policy matches `wrangler.toml`;
+6. documented bindings exist in the intended preview and production environments;
+7. no undocumented dashboard transform, redirect, or cache rule changes application semantics.
+
+Record intentional dashboard-only differences in this document before deployment.
+
+## Post-deploy smoke check
+
+After a configuration, Wrangler, adapter, or compatibility-date change, verify the production deployment:
+
+```sh
+curl -sS -D - https://micrantha.com/ -o /tmp/micrantha-home.html
+curl -sS -D - https://micrantha.com/contact -o /dev/null
+curl -sS -D - -X POST https://micrantha.com/services -o /tmp/micrantha-405.html
+curl -sS -D - https://micrantha.com/blog/ai-pipelines-need-control-boundaries \
+  -o /tmp/micrantha-article.html
+```
+
+Confirm:
+
+- `/` returns 200 with the expected CSP, cache, and security headers;
+- `/contact` returns 301 with `Location: /services`;
+- `POST /services` returns 405;
+- the article returns 200 with its canonical URL and Article JSON-LD;
+- generated CSS and browser assets return 200;
+- the deployed Worker remains within the recorded bundle budget.
+
+The post-deploy check validates CDN and dashboard behavior that a local workerd harness cannot reproduce. It does not replace required CI.

--- a/docs/operations/cloudflare-pages-configuration.md
+++ b/docs/operations/cloudflare-pages-configuration.md
@@ -16,14 +16,14 @@ Required CI runs `yarn test:cloudflare:config` to reject drift between:
 
 ## Contracted values
 
-| Setting | Required value |
-| --- | --- |
-| Pages project | `micrantha-web` |
-| Build output directory | `./public` |
-| Compatibility date | `2026-03-21` |
-| Compatibility flags | `nodejs_compat` |
-| Upload source maps | enabled |
-| Pages Function entry | `functions/[[path]].js` |
+| Setting                | Required value          |
+| ---------------------- | ----------------------- |
+| Pages project          | `micrantha-web`         |
+| Build output directory | `./public`              |
+| Compatibility date     | `2026-03-21`            |
+| Compatibility flags    | `nodejs_compat`         |
+| Upload source maps     | enabled                 |
+| Pages Function entry   | `functions/[[path]].js` |
 
 ## Dashboard-only configuration
 

--- a/package.json
+++ b/package.json
@@ -21,12 +21,13 @@
     "start": "remix-serve build/index.js",
     "test:cloudflare:adapter": "node scripts/test-cloudflare-adapter.js",
     "test:cloudflare:bundle-budget": "node scripts/check-cloudflare-bundle-budget.js",
+    "test:cloudflare:config": "node scripts/check-cloudflare-config.js",
     "test:cloudflare:runtime": "node scripts/stage-cloudflare-runtime.js && node scripts/test-cloudflare-runtime.js",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:mobile": "playwright test --project=mobile-chromium",
     "typecheck": "tsc -b",
-    "deploy:cloudflare": "yarn typecheck && yarn build && yarn cloudflare:functions:build && yarn test:cloudflare:bundle-budget && yarn test:cloudflare:adapter && yarn test:cloudflare:runtime && wrangler pages deploy public --project-name ${CLOUDFLARE_PAGES_PROJECT:-micrantha-web} --branch ${CLOUDFLARE_PAGES_BRANCH:-main} --upload-source-maps"
+    "deploy:cloudflare": "yarn typecheck && yarn test:cloudflare:config && yarn build && yarn cloudflare:functions:build && yarn test:cloudflare:bundle-budget && yarn test:cloudflare:adapter && yarn test:cloudflare:runtime && wrangler pages deploy public --project-name ${CLOUDFLARE_PAGES_PROJECT:-micrantha-web} --branch ${CLOUDFLARE_PAGES_BRANCH:-main} --upload-source-maps"
   },
   "dependencies": {
     "@remix-run/node": "2.17.4",

--- a/scripts/check-cloudflare-config.js
+++ b/scripts/check-cloudflare-config.js
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict"
+import { readFile, stat } from "node:fs/promises"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+)
+
+const [wranglerToml, contractDocument, packageDocument] = await Promise.all([
+  readFile(path.join(repositoryRoot, "wrangler.toml"), "utf8"),
+  readFile(
+    path.join(repositoryRoot, "config", "cloudflare-pages-contract.json"),
+    "utf8",
+  ),
+  readFile(path.join(repositoryRoot, "package.json"), "utf8"),
+])
+
+const contract = JSON.parse(contractDocument)
+const packageJson = JSON.parse(packageDocument)
+
+function tomlString(name) {
+  const value = wranglerToml.match(
+    new RegExp(`^${name}\\s*=\\s*"([^"]+)"\\s*$`, "m"),
+  )?.[1]
+
+  assert.ok(value, `wrangler.toml must define ${name}`)
+  return value
+}
+
+function tomlBoolean(name) {
+  const value = wranglerToml.match(
+    new RegExp(`^${name}\\s*=\\s*(true|false)\\s*$`, "m"),
+  )?.[1]
+
+  assert.ok(value, `wrangler.toml must define ${name}`)
+  return value === "true"
+}
+
+function tomlStringArray(name) {
+  const value = wranglerToml.match(
+    new RegExp(`^${name}\\s*=\\s*\\[([^\\]]*)\\]\\s*$`, "m"),
+  )?.[1]
+
+  assert.notEqual(value, undefined, `wrangler.toml must define ${name}`)
+
+  return [...value.matchAll(/"([^"]+)"/g)].map((match) => match[1])
+}
+
+assert.equal(tomlString("name"), contract.projectName)
+assert.equal(
+  tomlString("pages_build_output_dir"),
+  contract.pagesBuildOutputDirectory,
+)
+assert.equal(tomlString("compatibility_date"), contract.compatibilityDate)
+assert.deepEqual(
+  tomlStringArray("compatibility_flags").sort(),
+  [...contract.compatibilityFlags].sort(),
+)
+assert.equal(tomlBoolean("upload_source_maps"), contract.uploadSourceMaps)
+
+const deployCommand = packageJson.scripts?.["deploy:cloudflare"] ?? ""
+assert.match(
+  deployCommand,
+  /--project-name \$\{CLOUDFLARE_PAGES_PROJECT:-micrantha-web\}/,
+  "deploy:cloudflare must default to the contracted Pages project name",
+)
+assert.match(
+  deployCommand,
+  /wrangler pages deploy public/,
+  "deploy:cloudflare must deploy the contracted public output directory",
+)
+
+await stat(path.join(repositoryRoot, "functions", "[[path]].js"))
+
+for (const binding of contract.bindings) {
+  assert.match(binding.name, /^[A-Z][A-Z0-9_]*$/)
+  assert.equal(typeof binding.required, "boolean")
+  assert.equal(typeof binding.sensitive, "boolean")
+}
+
+console.log(
+  `Cloudflare Pages config passed (${contract.projectName}, ${contract.compatibilityDate}, ${contract.compatibilityFlags.join(", ")})`,
+)

--- a/scripts/test-cloudflare-adapter.js
+++ b/scripts/test-cloudflare-adapter.js
@@ -6,9 +6,15 @@ const { onRequest } = await import("../functions/[[path]].js")
 
 const origin = "https://micrantha.example"
 const analyticsId = "adapter-contract-test"
+const articlePath = "/blog/ai-pipelines-need-control-boundaries"
+const articleUrl = `https://micrantha.com${articlePath}`
 
-async function request(pathname, { userAgent = "adapter-contract" } = {}) {
+async function request(
+  pathname,
+  { userAgent = "adapter-contract", method = "GET" } = {},
+) {
   const request = new Request(new URL(pathname, origin), {
+    method,
     headers: {
       "User-Agent": userAgent,
     },
@@ -37,7 +43,11 @@ async function read(pathname, options) {
   return { response, body }
 }
 
-function assertDocumentHeaders(response, body, { requireNonce = true } = {}) {
+function assertDocumentHeaders(
+  response,
+  body,
+  { requireNonce = true, cacheControl } = {},
+) {
   assert.match(response.headers.get("content-type") ?? "", /^text\/html\b/)
   assert.equal(response.headers.get("x-content-type-options"), "nosniff")
   assert.equal(response.headers.get("x-frame-options"), "DENY")
@@ -53,7 +63,12 @@ function assertDocumentHeaders(response, body, { requireNonce = true } = {}) {
     response.headers.get("strict-transport-security"),
     "max-age=31536000",
   )
-  assert.ok(response.headers.get("cache-control"), "expected a cache policy")
+
+  if (cacheControl) {
+    assert.equal(response.headers.get("cache-control"), cacheControl)
+  } else {
+    assert.ok(response.headers.get("cache-control"), "expected a cache policy")
+  }
 
   const policy = response.headers.get("content-security-policy") ?? ""
 
@@ -70,28 +85,62 @@ function assertDocumentHeaders(response, body, { requireNonce = true } = {}) {
   )
 }
 
+function assertArticleMetadata(body) {
+  assert.match(
+    body,
+    new RegExp(`rel="canonical" href="${articleUrl.replaceAll("/", "\\/")}"`),
+  )
+  assert.match(body, /"@type":"Article"/)
+  assert.ok(
+    body.includes(`"url":"${articleUrl}"`),
+    "expected Article JSON-LD to contain the canonical URL",
+  )
+}
+
 const home = await read("/")
 assert.equal(home.response.status, 200)
 assert.match(home.body, /<!DOCTYPE html>/i)
 assert.match(home.body, /id="content"/)
 assert.match(home.body, new RegExp(`data-website-id="${analyticsId}"`))
-assertDocumentHeaders(home.response, home.body)
+assertDocumentHeaders(home.response, home.body, {
+  cacheControl:
+    "public, max-age=60, s-maxage=300, stale-while-revalidate=900",
+})
 
-const article = await read("/blog/ai-pipelines-need-control-boundaries")
+const contactRedirect = await read("/contact")
+assert.equal(contactRedirect.response.status, 301)
+assert.equal(contactRedirect.response.headers.get("location"), "/services")
+
+const article = await read(articlePath)
 assert.equal(article.response.status, 200)
 assert.match(article.body, /AI Pipelines Need Control Boundaries/)
 assert.match(
   article.body,
   /AI is not the system of record\. AI is an untrusted reasoning component/,
 )
-assertDocumentHeaders(article.response, article.body)
+assertArticleMetadata(article.body)
+assertDocumentHeaders(article.response, article.body, {
+  cacheControl:
+    "public, max-age=60, s-maxage=300, stale-while-revalidate=600",
+})
 
-const botArticle = await read("/blog/ai-pipelines-need-control-boundaries", {
+const botArticle = await read(articlePath, {
   userAgent: "Googlebot/2.1",
 })
 assert.equal(botArticle.response.status, 200)
 assert.match(botArticle.body, /AI Pipelines Need Control Boundaries/)
-assertDocumentHeaders(botArticle.response, botArticle.body)
+assertArticleMetadata(botArticle.body)
+assertDocumentHeaders(botArticle.response, botArticle.body, {
+  cacheControl:
+    "public, max-age=60, s-maxage=300, stale-while-revalidate=600",
+})
+
+const methodNotAllowed = await read("/services", { method: "POST" })
+assert.equal(methodNotAllowed.response.status, 405)
+assert.match(methodNotAllowed.body, /405|Method Not Allowed/i)
+assertDocumentHeaders(methodNotAllowed.response, methodNotAllowed.body, {
+  requireNonce: false,
+})
 
 const missing = await read("/this-route-does-not-exist")
 assert.equal(missing.response.status, 404)

--- a/scripts/test-cloudflare-adapter.js
+++ b/scripts/test-cloudflare-adapter.js
@@ -103,8 +103,7 @@ assert.match(home.body, /<!DOCTYPE html>/i)
 assert.match(home.body, /id="content"/)
 assert.match(home.body, new RegExp(`data-website-id="${analyticsId}"`))
 assertDocumentHeaders(home.response, home.body, {
-  cacheControl:
-    "public, max-age=60, s-maxage=300, stale-while-revalidate=900",
+  cacheControl: "public, max-age=60, s-maxage=300, stale-while-revalidate=900",
 })
 
 const contactRedirect = await read("/contact")
@@ -120,8 +119,7 @@ assert.match(
 )
 assertArticleMetadata(article.body)
 assertDocumentHeaders(article.response, article.body, {
-  cacheControl:
-    "public, max-age=60, s-maxage=300, stale-while-revalidate=600",
+  cacheControl: "public, max-age=60, s-maxage=300, stale-while-revalidate=600",
 })
 
 const botArticle = await read(articlePath, {
@@ -131,8 +129,7 @@ assert.equal(botArticle.response.status, 200)
 assert.match(botArticle.body, /AI Pipelines Need Control Boundaries/)
 assertArticleMetadata(botArticle.body)
 assertDocumentHeaders(botArticle.response, botArticle.body, {
-  cacheControl:
-    "public, max-age=60, s-maxage=300, stale-while-revalidate=600",
+  cacheControl: "public, max-age=60, s-maxage=300, stale-while-revalidate=600",
 })
 
 const methodNotAllowed = await read("/services", { method: "POST" })

--- a/scripts/test-cloudflare-runtime.js
+++ b/scripts/test-cloudflare-runtime.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { spawn } from "node:child_process"
-import { readFile, stat } from "node:fs/promises"
+import { readFile, stat, writeFile } from "node:fs/promises"
 import path from "node:path"
 import { setTimeout as delay } from "node:timers/promises"
 import { fileURLToPath } from "node:url"
@@ -20,7 +20,10 @@ const host = "127.0.0.1"
 const port = 8788
 const baseUrl = `http://${host}:${port}`
 const analyticsId = "cloudflare-runtime-contract"
+const articlePath = "/blog/ai-pipelines-need-control-boundaries"
+const articleUrl = `https://micrantha.com${articlePath}`
 const runtimeLog = []
+const runtimeStartedAt = Date.now()
 
 for (const requiredPath of [
   wranglerExecutable,
@@ -36,9 +39,13 @@ for (const requiredPath of [
   })
 }
 
-const manifest = JSON.parse(
-  await readFile(path.join(runtimeRoot, "manifest.json"), "utf8"),
-)
+const [manifest, runtimeBudget] = await Promise.all([
+  readFile(path.join(runtimeRoot, "manifest.json"), "utf8").then(JSON.parse),
+  readFile(
+    path.join(repositoryRoot, "config", "cloudflare-runtime-budget.json"),
+    "utf8",
+  ).then(JSON.parse),
+])
 assert.equal(manifest.schemaVersion, 1)
 assert.ok(manifest.files.length > 0)
 assert.equal(
@@ -48,6 +55,11 @@ assert.equal(
     ),
   ),
   false,
+)
+assert.ok(
+  Number.isInteger(runtimeBudget.localPagesReadyMilliseconds) &&
+    runtimeBudget.localPagesReadyMilliseconds > 0,
+  "local Pages readiness budget must be a positive integer",
 )
 
 function appendRuntimeLog(chunk) {
@@ -153,7 +165,7 @@ async function waitForRuntime() {
 
     try {
       const response = await fetchRuntime("/")
-      if (response.status === 200) return
+      if (response.status === 200) return Date.now() - runtimeStartedAt
     } catch {
       // The local socket is not ready yet.
     }
@@ -170,7 +182,11 @@ async function readRuntime(pathname, options) {
   return { response, body }
 }
 
-function assertDocumentHeaders(response, body, { requireNonce = true } = {}) {
+function assertDocumentHeaders(
+  response,
+  body,
+  { requireNonce = true, cacheControl } = {},
+) {
   assert.match(response.headers.get("content-type") ?? "", /^text\/html\b/)
   assert.equal(response.headers.get("x-content-type-options"), "nosniff")
   assert.equal(response.headers.get("x-frame-options"), "DENY")
@@ -186,7 +202,12 @@ function assertDocumentHeaders(response, body, { requireNonce = true } = {}) {
     response.headers.get("strict-transport-security"),
     "max-age=31536000",
   )
-  assert.ok(response.headers.get("cache-control"), "expected a cache policy")
+
+  if (cacheControl) {
+    assert.equal(response.headers.get("cache-control"), cacheControl)
+  } else {
+    assert.ok(response.headers.get("cache-control"), "expected a cache policy")
+  }
 
   const policy = response.headers.get("content-security-policy") ?? ""
 
@@ -200,8 +221,39 @@ function assertDocumentHeaders(response, body, { requireNonce = true } = {}) {
   )
 }
 
+function assertArticleMetadata(body) {
+  assert.ok(
+    body.includes(`rel="canonical" href="${articleUrl}"`),
+    "expected the article canonical URL",
+  )
+  assert.match(body, /"@type":"Article"/)
+  assert.ok(
+    body.includes(`"url":"${articleUrl}"`),
+    "expected Article JSON-LD to contain the canonical URL",
+  )
+}
+
 try {
-  await waitForRuntime()
+  const localPagesReadyMilliseconds = await waitForRuntime()
+  const runtimeReport = {
+    schemaVersion: 1,
+    measuredAt: new Date().toISOString(),
+    localPagesReadyMilliseconds,
+    budgetMilliseconds: runtimeBudget.localPagesReadyMilliseconds,
+    headroomMilliseconds:
+      runtimeBudget.localPagesReadyMilliseconds - localPagesReadyMilliseconds,
+    stagedFiles: manifest.files.length,
+    stagedBytes: manifest.totalBytes,
+  }
+
+  await writeFile(
+    path.join(runtimeRoot, "runtime-report.json"),
+    `${JSON.stringify(runtimeReport, null, 2)}\n`,
+  )
+  assert.ok(
+    localPagesReadyMilliseconds <= runtimeBudget.localPagesReadyMilliseconds,
+    `local Pages readiness ${localPagesReadyMilliseconds}ms exceeds budget ${runtimeBudget.localPagesReadyMilliseconds}ms`,
+  )
 
   const home = await readRuntime("/")
   assert.equal(home.response.status, 200)
@@ -209,7 +261,14 @@ try {
   assert.match(home.body, /id="content"/)
   assert.match(home.body, new RegExp(`data-website-id="${analyticsId}"`))
   assert.match(home.body, /https:\/\/micrantha\.com/)
-  assertDocumentHeaders(home.response, home.body)
+  assertDocumentHeaders(home.response, home.body, {
+    cacheControl:
+      "public, max-age=60, s-maxage=300, stale-while-revalidate=900",
+  })
+
+  const contactRedirect = await readRuntime("/contact")
+  assert.equal(contactRedirect.response.status, 301)
+  assert.equal(contactRedirect.response.headers.get("location"), "/services")
 
   const css = await readRuntime("/tailwind.css")
   assert.equal(css.response.status, 200)
@@ -229,33 +288,45 @@ try {
   )
   assert.ok(browserAsset.body.length > 1_000, "expected a browser bundle")
 
-  const article = await readRuntime(
-    "/blog/ai-pipelines-need-control-boundaries",
-  )
+  const article = await readRuntime(articlePath)
   assert.equal(article.response.status, 200)
   assert.match(article.body, /AI Pipelines Need Control Boundaries/)
   assert.match(
     article.body,
     /AI is not the system of record\. AI is an untrusted reasoning component/,
   )
-  assertDocumentHeaders(article.response, article.body)
+  assertArticleMetadata(article.body)
+  assertDocumentHeaders(article.response, article.body, {
+    cacheControl:
+      "public, max-age=60, s-maxage=300, stale-while-revalidate=600",
+  })
 
-  const botArticle = await readRuntime(
-    "/blog/ai-pipelines-need-control-boundaries",
-    {
-      headers: { "User-Agent": "Googlebot/2.1" },
-    },
-  )
+  const botArticle = await readRuntime(articlePath, {
+    headers: { "User-Agent": "Googlebot/2.1" },
+  })
   assert.equal(botArticle.response.status, 200)
   assert.match(botArticle.body, /AI Pipelines Need Control Boundaries/)
-  assertDocumentHeaders(botArticle.response, botArticle.body)
+  assertArticleMetadata(botArticle.body)
+  assertDocumentHeaders(botArticle.response, botArticle.body, {
+    cacheControl:
+      "public, max-age=60, s-maxage=300, stale-while-revalidate=600",
+  })
+
+  const methodNotAllowed = await readRuntime("/services", { method: "POST" })
+  assert.equal(methodNotAllowed.response.status, 405)
+  assert.match(methodNotAllowed.body, /405|Method Not Allowed/i)
+  assertDocumentHeaders(methodNotAllowed.response, methodNotAllowed.body, {
+    requireNonce: false,
+  })
 
   const missing = await readRuntime("/this-route-does-not-exist")
   assert.equal(missing.response.status, 404)
   assert.match(missing.body, /404|Not Found/i)
   assertDocumentHeaders(missing.response, missing.body, { requireNonce: false })
 
-  console.log("Cloudflare Pages runtime contract passed")
+  console.log(
+    `Cloudflare Pages runtime contract passed (${localPagesReadyMilliseconds}ms ready)`,
+  )
 } catch (error) {
   error.message += formattedRuntimeLog()
   throw error


### PR DESCRIPTION
Superseded after PR #83 merged the asset-first Workers Static Assets runtime harness into `main`. The remaining #56 closure work is being rebuilt from current `main` so it extends the corrected runtime topology instead of reintroducing the previous advanced-mode model.