### PR TITLE
[Superseded by #86 and #91] Verify redirect and controlled-error behavior through workerd

### DIFF
--- a/app/routes/runtime-contract.error.tsx
+++ b/app/routes/runtime-contract.error.tsx
@@ -1,0 +1,13 @@
+import type { LoaderFunctionArgs } from "@remix-run/node"
+
+import { assertRuntimeContractEnabled } from "../services/runtime-contract.server"
+
+export const loader = ({ context, request }: LoaderFunctionArgs) => {
+  assertRuntimeContractEnabled(context, request)
+
+  throw new Error("Controlled Cloudflare runtime contract failure")
+}
+
+export default function RuntimeContractError() {
+  return null
+}

--- a/app/routes/runtime-contract.redirect.tsx
+++ b/app/routes/runtime-contract.redirect.tsx
@@ -1,0 +1,21 @@
+import type { LoaderFunctionArgs } from "@remix-run/node"
+import { redirect } from "@remix-run/node"
+
+import { assertRuntimeContractEnabled } from "../services/runtime-contract.server"
+
+const REDIRECT_TARGET = "/blog/ai-pipelines-need-control-boundaries"
+
+export const loader = ({ context, request }: LoaderFunctionArgs) => {
+  assertRuntimeContractEnabled(context, request)
+
+  return redirect(REDIRECT_TARGET, {
+    status: 302,
+    headers: {
+      "Cache-Control": "private, no-store",
+    },
+  })
+}
+
+export default function RuntimeContractRedirect() {
+  return null
+}

--- a/app/services/runtime-contract.server.ts
+++ b/app/services/runtime-contract.server.ts
@@ -1,0 +1,34 @@
+import type { AppLoadContext } from "@remix-run/node"
+
+type RuntimeContractEnvironment = {
+  MICRANTHA_RUNTIME_CONTRACT?: string
+}
+
+type RuntimeContractContext = AppLoadContext & {
+  env?: RuntimeContractEnvironment
+  cloudflare?: {
+    env?: RuntimeContractEnvironment
+  }
+}
+
+export function assertRuntimeContractEnabled(
+  context: AppLoadContext,
+  request: Request,
+): void {
+  const runtimeContext = context as RuntimeContractContext
+  const enabled =
+    runtimeContext.env?.MICRANTHA_RUNTIME_CONTRACT ??
+    runtimeContext.cloudflare?.env?.MICRANTHA_RUNTIME_CONTRACT
+  const hostname = new URL(request.url).hostname
+  const isLoopback =
+    hostname === "127.0.0.1" || hostname === "localhost" || hostname === "[::1]"
+
+  if (!isLoopback || enabled !== "enabled") {
+    throw new Response("Not Found", {
+      status: 404,
+      headers: {
+        "Cache-Control": "private, no-store",
+      },
+    })
+  }
+}

--- a/scripts/test-cloudflare-adapter.js
+++ b/scripts/test-cloudflare-adapter.js
@@ -93,6 +93,17 @@ assert.equal(botArticle.response.status, 200)
 assert.match(botArticle.body, /AI Pipelines Need Control Boundaries/)
 assertDocumentHeaders(botArticle.response, botArticle.body)
 
+for (const contractPath of [
+  "/runtime-contract/redirect",
+  "/runtime-contract/error",
+]) {
+  const disabledContract = await read(contractPath)
+  assert.equal(disabledContract.response.status, 404)
+  assert.equal(disabledContract.response.headers.get("location"), null)
+  assert.match(disabledContract.body, /404|Not Found/i)
+  assertDocumentHeaders(disabledContract.response, disabledContract.body)
+}
+
 const missing = await read("/this-route-does-not-exist")
 assert.equal(missing.response.status, 404)
 assert.match(missing.body, /404|Not Found/i)

--- a/scripts/test-cloudflare-runtime.js
+++ b/scripts/test-cloudflare-runtime.js
@@ -308,12 +308,18 @@ try {
   const redirectResponse = await fetchRuntime("/runtime-contract/redirect")
   assert.equal(redirectResponse.status, 302)
   assert.equal(redirectResponse.headers.get("location"), articlePath)
-  assert.equal(redirectResponse.headers.get("cache-control"), "private, no-store")
+  assert.equal(
+    redirectResponse.headers.get("cache-control"),
+    "private, no-store",
+  )
   await redirectResponse.body?.cancel()
 
   const controlledError = await readRuntime("/runtime-contract/error")
   assert.equal(controlledError.response.status, 500)
-  assert.match(controlledError.body, /Unexpected Server Error|Internal Server Error/i)
+  assert.match(
+    controlledError.body,
+    /Unexpected Server Error|Internal Server Error/i,
+  )
   assertDocumentHeaders(controlledError.response, controlledError.body)
 
   const missing = await readRuntime("/this-route-does-not-exist")

--- a/scripts/test-cloudflare-runtime.js
+++ b/scripts/test-cloudflare-runtime.js
@@ -118,6 +118,8 @@ const runtime = spawn(
     "http",
     "--var",
     `MICRANTHA_ANALYTICS_ID:${analyticsId}`,
+    "--var",
+    "MICRANTHA_RUNTIME_CONTRACT:enabled",
     "--show-interactive-dev-session=false",
   ],
   {
@@ -302,6 +304,17 @@ try {
   assert.equal(botArticle.response.status, 200)
   assert.match(botArticle.body, /AI Pipelines Need Control Boundaries/)
   assertDocumentHeaders(botArticle.response, botArticle.body)
+
+  const redirectResponse = await fetchRuntime("/runtime-contract/redirect")
+  assert.equal(redirectResponse.status, 302)
+  assert.equal(redirectResponse.headers.get("location"), articlePath)
+  assert.equal(redirectResponse.headers.get("cache-control"), "private, no-store")
+  await redirectResponse.body?.cancel()
+
+  const controlledError = await readRuntime("/runtime-contract/error")
+  assert.equal(controlledError.response.status, 500)
+  assert.match(controlledError.body, /Unexpected Server Error|Internal Server Error/i)
+  assertDocumentHeaders(controlledError.response, controlledError.body)
 
   const missing = await readRuntime("/this-route-does-not-exist")
   assert.equal(missing.response.status, 404)


### PR DESCRIPTION
Superseded by merged PR #86 and focused PR #91.

PR #86 already delivered the permanent redirect and deterministic 405 contracts. PR #91 starts from current `main` and contains only the remaining thrown-500 fixture and its production-safety/workerd assertions.