### PR TITLE
Verify a thrown 500 response through workerd

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -76,7 +76,7 @@ export const meta: MetaFunction = () => buildSiteMeta()
 
 export const headers: HeadersFunction = ({ errorHeaders, loaderHeaders }) => {
   const cacheControl =
-    errorHeaders.get("Cache-Control") ??
+    errorHeaders?.get("Cache-Control") ??
     loaderHeaders.get("Cache-Control") ??
     "public, max-age=60, s-maxage=300, stale-while-revalidate=600"
   const nonce = loaderHeaders.get(NONCE_HEADER)

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -74,8 +74,9 @@ export const links: LinksFunction = () => [
 
 export const meta: MetaFunction = () => buildSiteMeta()
 
-export const headers: HeadersFunction = ({ loaderHeaders }) => {
+export const headers: HeadersFunction = ({ errorHeaders, loaderHeaders }) => {
   const cacheControl =
+    errorHeaders.get("Cache-Control") ??
     loaderHeaders.get("Cache-Control") ??
     "public, max-age=60, s-maxage=300, stale-while-revalidate=600"
   const nonce = loaderHeaders.get(NONCE_HEADER)

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -15,6 +15,7 @@ import {
   useLoaderData,
   useMatches,
   useRouteError,
+  useRouteLoaderData,
 } from "@remix-run/react"
 
 import { Navigation, Footer, Analytics } from "./components"
@@ -202,14 +203,24 @@ export default function App() {
 
 export function ErrorBoundary() {
   const error = useRouteError()
-  const state = useLoaderData() as State | null
-  const isResponse = isRouteErrorResponse(error)
-  const status = isResponse ? error.status : 500
-  const title = status === 404 ? "Not Found" : "Unexpected Server Error"
+  const state = useRouteLoaderData("root") as State | undefined
+  const status = isRouteErrorResponse(error) ? error.status : 500
+  const title =
+    status === 404
+      ? "Not Found"
+      : status === 405
+        ? "Method Not Allowed"
+        : status >= 500
+          ? "Unexpected Server Error"
+          : "Request Error"
   const message =
     status === 404
       ? "The requested page could not be found."
-      : "The request could not be completed. Please try again later."
+      : status === 405
+        ? "The requested method is not supported for this page."
+        : status >= 500
+          ? "The request could not be completed. Please try again later."
+          : "The request could not be completed."
 
   return (
     <html lang="en">

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -5,6 +5,7 @@ import type {
   LoaderFunctionArgs,
 } from "@remix-run/node"
 import {
+  isRouteErrorResponse,
   Links,
   LiveReload,
   Meta,
@@ -13,6 +14,7 @@ import {
   ScrollRestoration,
   useLoaderData,
   useMatches,
+  useRouteError,
 } from "@remix-run/react"
 
 import { Navigation, Footer, Analytics } from "./components"
@@ -193,6 +195,56 @@ export default function App() {
         <Scripts nonce={state?.nonce} />
         <Analytics id={state?.analyticsId} nonce={state?.nonce} />
         {isDev ? <LiveReload nonce={state?.nonce} /> : null}
+      </body>
+    </html>
+  )
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError()
+  const state = useLoaderData() as State | null
+  const isResponse = isRouteErrorResponse(error)
+  const status = isResponse ? error.status : 500
+  const title = status === 404 ? "Not Found" : "Unexpected Server Error"
+  const message =
+    status === 404
+      ? "The requested page could not be found."
+      : "The request could not be completed. Please try again later."
+
+  return (
+    <html lang="en">
+      <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>{`${status} ${title} | Micrantha Software`}</title>
+        <Links />
+        {state?.nonce ? (
+          <script
+            nonce={state.nonce}
+            type="application/json"
+            dangerouslySetInnerHTML={{ __html: '{"error":true}' }}
+          />
+        ) : null}
+      </head>
+      <body>
+        <a className="skip-link" href="#content">
+          Skip to content
+        </a>
+        <main
+          id="content"
+          tabIndex={-1}
+          className="body mx-auto w-full max-w-3xl px-4 py-16 sm:px-6 lg:px-8"
+        >
+          <p className="meta-kicker">Error {status}</p>
+          <h1 className="mt-3 text-4xl font-semibold tracking-[-0.04em] text-slate-900">
+            {title}
+          </h1>
+          <p className="page-copy mt-4">{message}</p>
+          <p className="mt-6">
+            <a className="article-meta-link" href="/">
+              Return to Micrantha Software
+            </a>
+          </p>
+        </main>
       </body>
     </html>
   )

--- a/app/routes/runtime-contract.error.tsx
+++ b/app/routes/runtime-contract.error.tsx
@@ -1,0 +1,13 @@
+import type { LoaderFunctionArgs } from "@remix-run/node"
+
+import { assertRuntimeContractEnabled } from "../services/runtime-contract.server"
+
+export const loader = ({ context, request }: LoaderFunctionArgs) => {
+  assertRuntimeContractEnabled(context, request)
+
+  throw new Error("Controlled Cloudflare runtime contract failure")
+}
+
+export default function RuntimeContractError() {
+  return null
+}

--- a/app/services/cache-policy.server.ts
+++ b/app/services/cache-policy.server.ts
@@ -18,6 +18,10 @@ const CACHE_MATRIX: CacheRule[] = [
 ]
 
 export function getDocumentCacheControl(pathname: string): string {
+  if (/^\/runtime-contract(?:\/|$)/.test(pathname)) {
+    return "private, no-store"
+  }
+
   const rule = CACHE_MATRIX.find((entry) => entry.pattern.test(pathname)) ?? {
     ttlSeconds: DEFAULT_TTL_SECONDS,
     staleSeconds: DEFAULT_STALE_SECONDS,

--- a/app/services/runtime-contract.server.ts
+++ b/app/services/runtime-contract.server.ts
@@ -1,0 +1,34 @@
+import type { AppLoadContext } from "@remix-run/node"
+
+type RuntimeContractEnvironment = {
+  MICRANTHA_RUNTIME_CONTRACT?: string
+}
+
+type RuntimeContractContext = AppLoadContext & {
+  env?: RuntimeContractEnvironment
+  cloudflare?: {
+    env?: RuntimeContractEnvironment
+  }
+}
+
+export function assertRuntimeContractEnabled(
+  context: AppLoadContext,
+  request: Request,
+): void {
+  const runtimeContext = context as RuntimeContractContext
+  const enabled =
+    runtimeContext.env?.MICRANTHA_RUNTIME_CONTRACT ??
+    runtimeContext.cloudflare?.env?.MICRANTHA_RUNTIME_CONTRACT
+  const hostname = new URL(request.url).hostname
+  const isLoopback =
+    hostname === "127.0.0.1" || hostname === "localhost" || hostname === "[::1]"
+
+  if (!isLoopback || enabled !== "enabled") {
+    throw new Response("Not Found", {
+      status: 404,
+      headers: {
+        "Cache-Control": "private, no-store",
+      },
+    })
+  }
+}

--- a/scripts/test-cloudflare-adapter.js
+++ b/scripts/test-cloudflare-adapter.js
@@ -115,6 +115,7 @@ assert.match(disabledErrorContract.body, /404|Not Found/i)
 assertDocumentHeaders(
   disabledErrorContract.response,
   disabledErrorContract.body,
+  { requireNonce: false },
 )
 
 const missing = await read("/this-route-does-not-exist")

--- a/scripts/test-cloudflare-adapter.js
+++ b/scripts/test-cloudflare-adapter.js
@@ -59,12 +59,11 @@ function assertDocumentHeaders(response, body, { requireNonce = true } = {}) {
   )
   assert.ok(response.headers.get("cache-control"), "expected a cache policy")
 
-  const policy = response.headers.get("content-security-policy") ?? ""
-
-  if (!requireNonce && !policy) {
+  if (!requireNonce) {
     return
   }
 
+  const policy = response.headers.get("content-security-policy") ?? ""
   const nonce = policy.match(/'nonce-([^']+)'/)?.[1]
 
   assert.ok(nonce, "expected a CSP nonce in the document response")
@@ -112,6 +111,10 @@ assertDocumentHeaders(methodNotAllowed.response, methodNotAllowed.body, {
 const disabledErrorContract = await read("/runtime-contract/error")
 assert.equal(disabledErrorContract.response.status, 404)
 assert.match(disabledErrorContract.body, /404|Not Found/i)
+assert.equal(
+  disabledErrorContract.response.headers.get("cache-control"),
+  "private, no-store",
+)
 assertDocumentHeaders(
   disabledErrorContract.response,
   disabledErrorContract.body,

--- a/scripts/test-cloudflare-adapter.js
+++ b/scripts/test-cloudflare-adapter.js
@@ -109,6 +109,14 @@ assertDocumentHeaders(methodNotAllowed.response, methodNotAllowed.body, {
   requireNonce: false,
 })
 
+const disabledErrorContract = await read("/runtime-contract/error")
+assert.equal(disabledErrorContract.response.status, 404)
+assert.match(disabledErrorContract.body, /404|Not Found/i)
+assertDocumentHeaders(
+  disabledErrorContract.response,
+  disabledErrorContract.body,
+)
+
 const missing = await read("/this-route-does-not-exist")
 assert.equal(missing.response.status, 404)
 assert.match(missing.body, /404|Not Found/i)

--- a/scripts/test-cloudflare-runtime.js
+++ b/scripts/test-cloudflare-runtime.js
@@ -323,6 +323,10 @@ try {
     controlledError.body,
     /Unexpected Server Error|Internal Server Error/i,
   )
+  assert.equal(
+    controlledError.response.headers.get("cache-control"),
+    "private, no-store",
+  )
   assertDocumentHeaders(controlledError.response, controlledError.body)
 
   const missing = await readRuntime("/this-route-does-not-exist")

--- a/scripts/test-cloudflare-runtime.js
+++ b/scripts/test-cloudflare-runtime.js
@@ -318,7 +318,7 @@ try {
 
   const controlledError = await readRuntime("/runtime-contract/error")
   assert.equal(controlledError.response.status, 500)
-  assert.match(controlledError.body, /Application Error/i)
+  assert.match(controlledError.body, /Unexpected Server Error/i)
   assert.doesNotMatch(
     controlledError.body,
     /Controlled Cloudflare runtime contract failure/,
@@ -327,13 +327,7 @@ try {
     controlledError.response.headers.get("cache-control"),
     "private, no-store",
   )
-  assert.match(
-    controlledError.response.headers.get("content-security-policy") ?? "",
-    /script-src/,
-  )
-  assertDocumentHeaders(controlledError.response, controlledError.body, {
-    requireNonce: false,
-  })
+  assertDocumentHeaders(controlledError.response, controlledError.body)
 
   const missing = await readRuntime("/this-route-does-not-exist")
   assert.equal(missing.response.status, 404)

--- a/scripts/test-cloudflare-runtime.js
+++ b/scripts/test-cloudflare-runtime.js
@@ -240,10 +240,9 @@ function assertDocumentHeaders(response, body, { requireNonce = true } = {}) {
   )
   assert.ok(response.headers.get("cache-control"), "expected a cache policy")
 
+  if (!requireNonce) return
+
   const policy = response.headers.get("content-security-policy") ?? ""
-
-  if (!requireNonce && !policy) return
-
   const nonce = policy.match(/'nonce-([^']+)'/)?.[1]
   assert.ok(nonce, "expected a CSP nonce in the document response")
   assert.ok(
@@ -319,15 +318,22 @@ try {
 
   const controlledError = await readRuntime("/runtime-contract/error")
   assert.equal(controlledError.response.status, 500)
-  assert.match(
+  assert.match(controlledError.body, /Application Error/i)
+  assert.doesNotMatch(
     controlledError.body,
-    /Unexpected Server Error|Internal Server Error/i,
+    /Controlled Cloudflare runtime contract failure/,
   )
   assert.equal(
     controlledError.response.headers.get("cache-control"),
     "private, no-store",
   )
-  assertDocumentHeaders(controlledError.response, controlledError.body)
+  assert.match(
+    controlledError.response.headers.get("content-security-policy") ?? "",
+    /script-src/,
+  )
+  assertDocumentHeaders(controlledError.response, controlledError.body, {
+    requireNonce: false,
+  })
 
   const missing = await readRuntime("/this-route-does-not-exist")
   assert.equal(missing.response.status, 404)

--- a/scripts/test-cloudflare-runtime.js
+++ b/scripts/test-cloudflare-runtime.js
@@ -118,6 +118,8 @@ const runtime = spawn(
     "http",
     "--var",
     `MICRANTHA_ANALYTICS_ID:${analyticsId}`,
+    "--var",
+    "MICRANTHA_RUNTIME_CONTRACT:enabled",
     "--show-interactive-dev-session=false",
   ],
   {
@@ -314,6 +316,14 @@ try {
   assertDocumentHeaders(methodNotAllowed.response, methodNotAllowed.body, {
     requireNonce: false,
   })
+
+  const controlledError = await readRuntime("/runtime-contract/error")
+  assert.equal(controlledError.response.status, 500)
+  assert.match(
+    controlledError.body,
+    /Unexpected Server Error|Internal Server Error/i,
+  )
+  assertDocumentHeaders(controlledError.response, controlledError.body)
 
   const missing = await readRuntime("/this-route-does-not-exist")
   assert.equal(missing.response.status, 404)


### PR DESCRIPTION
## Summary

- add a localhost-and-binding-gated route that throws a deterministic server error
- prove the route remains a private no-store 404 through the normal production adapter
- enable it only in the source-isolated workerd runtime with `MICRANTHA_RUNTIME_CONTRACT=enabled`
- require a 500 HTML error document with baseline security headers, private cache policy, and CSP nonce pairing
- classify all `/runtime-contract/*` documents as `private, no-store` at the root cache-policy boundary
- replace Remix’s generic fallback with an application-owned SSR-only root error document

## Context

PR #86 merged permanent redirect and deterministic 405 coverage through both the direct Pages adapter and workerd. Issue #56 is closed; this PR adds deeper error, cache-safety, and CSP coverage owned by #58.

## Safety boundary

`assertRuntimeContractEnabled` requires both:

1. a loopback hostname (`127.0.0.1`, `localhost`, or `[::1]`); and
2. the exact runtime binding `MICRANTHA_RUNTIME_CONTRACT=enabled`.

Without both conditions, `/runtime-contract/error` throws a private 404. The root cache policy independently classifies the entire `/runtime-contract/*` namespace as `private, no-store`.

## Root error document

The first workerd run exposed Remix’s built-in fallback document. That fallback included an inline diagnostic script without the application CSP nonce. The root route now exports a minimal error boundary that:

- reads root loader data through `useRouteLoaderData("root")`, avoiding `useLoaderData` failure recursion in an error boundary;
- renders complete HTML without client hydration;
- retains the root loader nonce when available;
- contains no exception message or stack trace;
- distinguishes 404, 405, and unexpected server errors;
- provides a simple return link;
- avoids Remix’s un-nonced diagnostic script.

The root header function also preserves conservative `errorHeaders` cache policy before considering normal loader headers.

## Runtime contract

With the local binding enabled, the route throws `Controlled Cloudflare runtime contract failure`. The source-isolated workerd test requires:

- status `500`;
- the application-owned `Unexpected Server Error` document;
- no controlled exception text in the response body;
- framing, MIME-sniffing, permissions, referrer, and HSTS headers;
- exact `private, no-store` cache policy;
- CSP header/body nonce pairing.

## Validation

Successful required CI run: `30865220533`

### Quality — passed

- frozen install
- full-repository Prettier and ESLint
- typecheck and production Remix build
- pinned Wrangler verification
- Pages Function compilation and bundle budgets
- direct adapter safety assertion
- asset-first source-isolated workerd 500 contract
- runtime manifest upload

### End-to-end — passed

- complete functional Playwright suite on desktop and mobile Chromium
- no failure artifacts

Progresses #58. Production CDN/cache validation and response timing remain in that issue; the JavaScript-disabled MDX route remains in #55.