### PR TITLE
Add the first SSR-safe MDX blog vertical slice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Build
         run: yarn build
 
+      - name: Test MDX browser chunk isolation
+        run: yarn test:mdx:build
+
       - name: Verify pinned Wrangler
         run: yarn wrangler --version
 

--- a/app/components/blog-article-layout.tsx
+++ b/app/components/blog-article-layout.tsx
@@ -2,8 +2,8 @@ import type { ReactNode } from "react"
 import { Link } from "@remix-run/react"
 
 import { PageTitle } from "~/components"
+import { formatBlogDate } from "~/content/blog-format"
 import type { BlogPostMetadata } from "~/content/blog-mdx"
-import { formatBlogDate } from "~/content/blog"
 
 export type BlogArticleSeriesNavigation = {
   series: {

--- a/app/components/blog-article-layout.tsx
+++ b/app/components/blog-article-layout.tsx
@@ -1,0 +1,150 @@
+import type { ReactNode } from "react"
+import { Link } from "@remix-run/react"
+
+import { PageTitle } from "~/components"
+import type { BlogPostMetadata } from "~/content/blog-mdx"
+import { formatBlogDate } from "~/content/blog"
+
+export type BlogArticleSeriesNavigation = {
+  series: {
+    slug: string
+    title: string
+  }
+  index: number
+  total: number
+  previous: BlogPostMetadata | null
+  next: BlogPostMetadata | null
+  posts: BlogPostMetadata[]
+}
+
+type BlogArticleLayoutProps = {
+  children: ReactNode
+  post: BlogPostMetadata
+  relatedPosts: BlogPostMetadata[]
+  seriesNavigation: BlogArticleSeriesNavigation | null
+}
+
+export function BlogArticleLayout({
+  children,
+  post,
+  relatedPosts,
+  seriesNavigation,
+}: BlogArticleLayoutProps) {
+  return (
+    <article className="space-y-10">
+      <div className="space-y-5">
+        <Link className="article-meta-link inline-flex text-sm" to="/blog">
+          Back to blog
+        </Link>
+        <PageTitle title={post.title} subtitle={post.description} />
+        <div className="article-meta-row flex flex-wrap items-center gap-x-4 gap-y-2">
+          <time dateTime={post.date}>{formatBlogDate(post.date)}</time>
+          <span aria-hidden="true">/</span>
+          <span>{post.tags.join(", ")}</span>
+        </div>
+        <p className="article-lead">{post.excerpt}</p>
+      </div>
+
+      {seriesNavigation ? (
+        <section className="max-w-3xl rounded-2xl border border-slate-200 bg-slate-50/80 px-5 py-5 shadow-[0_10px_24px_rgba(31,42,42,0.05)]">
+          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div className="space-y-2">
+              <p className="meta-kicker">Series</p>
+              <h2 className="text-[1.25rem] font-semibold tracking-[-0.02em] text-slate-900">
+                <Link to={`/blog/series/${seriesNavigation.series.slug}`}>
+                  {seriesNavigation.series.title}
+                </Link>
+              </h2>
+              <p className="page-copy-sm">
+                Part {seriesNavigation.index + 1} of {seriesNavigation.total}
+              </p>
+            </div>
+            <nav
+              className="grid gap-2 text-sm md:min-w-[16rem]"
+              aria-label={`${seriesNavigation.series.title} series navigation`}
+            >
+              {seriesNavigation.previous ? (
+                <Link
+                  className="article-meta-link"
+                  to={`/blog/${seriesNavigation.previous.slug}`}
+                >
+                  Previous: {seriesNavigation.previous.title}
+                </Link>
+              ) : null}
+              {seriesNavigation.next ? (
+                <Link
+                  className="article-meta-link"
+                  to={`/blog/${seriesNavigation.next.slug}`}
+                >
+                  Next: {seriesNavigation.next.title}
+                </Link>
+              ) : null}
+            </nav>
+          </div>
+        </section>
+      ) : null}
+
+      <div className="article-prose">{children}</div>
+
+      {seriesNavigation ? (
+        <section className="max-w-3xl space-y-4 border-t border-gray-200 pt-8">
+          <h2 className="text-[1.35rem] font-semibold tracking-[-0.02em] text-slate-900">
+            In this series
+          </h2>
+          <div className="grid gap-3">
+            {seriesNavigation.posts.map((seriesPost, index) => {
+              const isCurrent = seriesPost.slug === post.slug
+
+              return (
+                <Link
+                  key={seriesPost.slug}
+                  to={`/blog/${seriesPost.slug}`}
+                  aria-current={isCurrent ? "page" : undefined}
+                  className={
+                    isCurrent
+                      ? "rounded-2xl border border-slate-300 bg-white px-4 py-4 text-left text-base shadow-[0_10px_24px_rgba(31,42,42,0.08)]"
+                      : "rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-4 text-left text-base shadow-[0_10px_24px_rgba(31,42,42,0.05)] transition-colors hover:bg-white"
+                  }
+                >
+                  <span className="meta-kicker mb-1 block">
+                    Part {index + 1}
+                  </span>
+                  <span className="block text-[1.02rem] font-semibold leading-7 tracking-[-0.015em] text-slate-900">
+                    {seriesPost.title}
+                  </span>
+                  <span className="mt-2 block text-sm leading-7 text-slate-600">
+                    {seriesPost.excerpt}
+                  </span>
+                </Link>
+              )
+            })}
+          </div>
+        </section>
+      ) : null}
+
+      {relatedPosts.length > 0 ? (
+        <section className="max-w-3xl space-y-4 border-t border-gray-200 pt-8">
+          <h2 className="text-[1.35rem] font-semibold tracking-[-0.02em] text-slate-900">
+            Related notes
+          </h2>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            {relatedPosts.map((relatedPost) => (
+              <Link
+                key={relatedPost.slug}
+                to={`/blog/${relatedPost.slug}`}
+                className="rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-4 text-left text-base shadow-[0_10px_24px_rgba(31,42,42,0.05)] transition-colors hover:bg-white"
+              >
+                <span className="block text-[1.02rem] font-semibold leading-7 tracking-[-0.015em] text-slate-900">
+                  {relatedPost.title}
+                </span>
+                <span className="mt-2 block text-sm leading-7 text-slate-600">
+                  {relatedPost.excerpt}
+                </span>
+              </Link>
+            ))}
+          </div>
+        </section>
+      ) : null}
+    </article>
+  )
+}

--- a/app/components/blog-mdx-components.tsx
+++ b/app/components/blog-mdx-components.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from "react"
+import { Link } from "@remix-run/react"
+
+type CalloutProps = {
+  children: ReactNode
+}
+
+export function Callout({ children }: CalloutProps) {
+  return (
+    <aside className="article-callout" aria-label="Key point">
+      {children}
+    </aside>
+  )
+}
+
+type FigureProps = {
+  alt: string
+  caption: string
+  src: string
+  title: string
+  narrow?: boolean
+}
+
+export function Figure({ alt, caption, src, title, narrow }: FigureProps) {
+  return (
+    <figure className={`article-figure${narrow ? " article-figure-narrow" : ""}`}>
+      <div className="article-figure-heading">
+        <h2>{title}</h2>
+        <p>{caption}</p>
+      </div>
+      <div className="article-figure-canvas">
+        <img src={src} alt={alt} loading="lazy" decoding="async" />
+      </div>
+    </figure>
+  )
+}
+
+type PostLinkProps = {
+  children: ReactNode
+  slug: string
+}
+
+export function PostLink({ children, slug }: PostLinkProps) {
+  return <Link to={`/blog/${slug}`}>{children}</Link>
+}
+
+export const blogMdxComponents = {
+  Callout,
+  Figure,
+  PostLink,
+}

--- a/app/components/blog-mdx-components.tsx
+++ b/app/components/blog-mdx-components.tsx
@@ -23,7 +23,9 @@ type FigureProps = {
 
 export function Figure({ alt, caption, src, title, narrow }: FigureProps) {
   return (
-    <figure className={`article-figure${narrow ? " article-figure-narrow" : ""}`}>
+    <figure
+      className={`article-figure${narrow ? " article-figure-narrow" : ""}`}
+    >
       <div className="article-figure-heading">
         <h2>{title}</h2>
         <p>{caption}</p>

--- a/app/content/ai-pipeline-post.server.ts
+++ b/app/content/ai-pipeline-post.server.ts
@@ -1,0 +1,9 @@
+import { defineBlogMdxPost } from "~/content/blog-mdx"
+import { attributes } from "~/content/posts/ai-pipelines-need-control-boundaries.mdx"
+
+export const AI_PIPELINE_POST_SLUG = "ai-pipelines-need-control-boundaries"
+
+export const aiPipelinePost = defineBlogMdxPost(
+  attributes,
+  AI_PIPELINE_POST_SLUG,
+)

--- a/app/content/ai-pipeline-route.server.ts
+++ b/app/content/ai-pipeline-route.server.ts
@@ -1,0 +1,106 @@
+import {
+  AI_PIPELINE_POST_SLUG,
+  aiPipelinePost,
+} from "~/content/ai-pipeline-post.server"
+import type { BlogArticleSeriesNavigation } from "~/components/blog-article-layout"
+import type { BlogPostMetadata } from "~/content/blog-mdx"
+import { getBlogPostBySlug } from "~/content/blog-provider"
+import { getSeriesNavigation } from "~/content/blog-series"
+
+export type AiPipelineRouteData = {
+  post: BlogPostMetadata
+  relatedPosts: BlogPostMetadata[]
+  seriesNavigation: BlogArticleSeriesNavigation
+}
+
+function toMetadata(candidate: BlogPostMetadata): BlogPostMetadata {
+  return {
+    slug: candidate.slug,
+    title: candidate.title,
+    description: candidate.description,
+    date: candidate.date,
+    excerpt: candidate.excerpt,
+    tags: [...candidate.tags],
+    relatedSlugs: [...candidate.relatedSlugs],
+    series: candidate.series ? { ...candidate.series } : undefined,
+  }
+}
+
+function comparableMetadata(candidate: BlogPostMetadata) {
+  const metadata = toMetadata(candidate)
+
+  delete metadata.series
+
+  return metadata
+}
+
+function assertLegacyMetadataMatchesMdx(legacyPost: BlogPostMetadata) {
+  if (
+    JSON.stringify(comparableMetadata(legacyPost)) !==
+    JSON.stringify(comparableMetadata(aiPipelinePost))
+  ) {
+    throw new Error(
+      `Legacy metadata drifted from MDX frontmatter for ${AI_PIPELINE_POST_SLUG}`,
+    )
+  }
+}
+
+function resolveRelatedPosts() {
+  return aiPipelinePost.relatedSlugs.map((slug) => {
+    const relatedPost = getBlogPostBySlug(slug)
+
+    if (!relatedPost) {
+      throw new Error(`MDX related post does not exist: ${slug}`)
+    }
+
+    return toMetadata(relatedPost)
+  })
+}
+
+export function getAiPipelineRouteData(): AiPipelineRouteData {
+  const legacyPost = getBlogPostBySlug(AI_PIPELINE_POST_SLUG)
+
+  if (!legacyPost) {
+    throw new Error("MDX compatibility metadata is missing")
+  }
+
+  assertLegacyMetadataMatchesMdx(legacyPost)
+
+  const series = getSeriesNavigation(legacyPost)
+
+  if (!series || !aiPipelinePost.series) {
+    throw new Error(
+      `MDX series metadata is missing for ${AI_PIPELINE_POST_SLUG}`,
+    )
+  }
+
+  if (
+    aiPipelinePost.series.slug !== series.series.slug ||
+    aiPipelinePost.series.title !== series.series.title ||
+    aiPipelinePost.series.order !== series.index + 1
+  ) {
+    throw new Error(
+      `MDX series metadata drifted for ${AI_PIPELINE_POST_SLUG}`,
+    )
+  }
+
+  return {
+    post: aiPipelinePost,
+    relatedPosts: resolveRelatedPosts(),
+    seriesNavigation: {
+      series: {
+        slug: aiPipelinePost.series.slug,
+        title: aiPipelinePost.series.title,
+      },
+      index: aiPipelinePost.series.order - 1,
+      total: series.total,
+      previous: series.previous ? toMetadata(series.previous) : null,
+      next: series.next ? toMetadata(series.next) : null,
+      posts: series.posts.map((seriesPost) =>
+        seriesPost.slug === AI_PIPELINE_POST_SLUG
+          ? aiPipelinePost
+          : toMetadata(seriesPost),
+      ),
+    },
+  }
+}

--- a/app/content/blog-format.ts
+++ b/app/content/blog-format.ts
@@ -1,0 +1,13 @@
+export const BLOG_TITLE = "Architecture Notes"
+
+export const BLOG_DESCRIPTION =
+  "Practical notes on secure integration, delivery governance, AI-assisted systems, and durable software boundaries."
+
+export function formatBlogDate(date: string) {
+  return new Intl.DateTimeFormat("en-CA", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(`${date}T00:00:00Z`))
+}

--- a/app/content/blog-format.ts
+++ b/app/content/blog-format.ts
@@ -1,10 +1,10 @@
 export const BLOG_TITLE = "Architecture Notes"
 
 export const BLOG_DESCRIPTION =
-  "Practical notes on secure integration, delivery governance, AI-assisted systems, and durable software boundaries."
+  "Architecture notes on secure platform integration, delivery governance, AI-assisted systems, and long-lived software design."
 
 export function formatBlogDate(date: string) {
-  return new Intl.DateTimeFormat("en-CA", {
+  return new Intl.DateTimeFormat("en-US", {
     year: "numeric",
     month: "long",
     day: "numeric",

--- a/app/content/blog-index.server.ts
+++ b/app/content/blog-index.server.ts
@@ -1,0 +1,49 @@
+import {
+  AI_PIPELINE_POST_SLUG,
+  aiPipelinePost,
+} from "~/content/ai-pipeline-post.server"
+import type { BlogPostMetadata } from "~/content/blog-mdx"
+import { getBlogPosts } from "~/content/blog-provider"
+import { getSeriesNavigation } from "~/content/blog-series"
+
+export type BlogIndexPost = BlogPostMetadata & {
+  series?: {
+    slug: string
+    title: string
+    order: number
+  }
+}
+
+function toMetadata(candidate: BlogPostMetadata): BlogPostMetadata {
+  return {
+    slug: candidate.slug,
+    title: candidate.title,
+    description: candidate.description,
+    date: candidate.date,
+    excerpt: candidate.excerpt,
+    tags: [...candidate.tags],
+    relatedSlugs: [...candidate.relatedSlugs],
+    series: candidate.series ? { ...candidate.series } : undefined,
+  }
+}
+
+export function getBlogIndexPosts(): BlogIndexPost[] {
+  return getBlogPosts().map((legacyPost) => {
+    if (legacyPost.slug === AI_PIPELINE_POST_SLUG) {
+      return aiPipelinePost
+    }
+
+    const series = getSeriesNavigation(legacyPost)
+
+    return {
+      ...toMetadata(legacyPost),
+      series: series
+        ? {
+            slug: series.series.slug,
+            title: series.series.title,
+            order: series.index + 1,
+          }
+        : undefined,
+    }
+  })
+}

--- a/app/content/blog-mdx.ts
+++ b/app/content/blog-mdx.ts
@@ -1,3 +1,9 @@
+export type BlogSeriesMetadata = {
+  slug: string
+  title: string
+  order: number
+}
+
 export type BlogPostMetadata = {
   slug: string
   title: string
@@ -6,6 +12,7 @@ export type BlogPostMetadata = {
   excerpt: string
   tags: string[]
   relatedSlugs: string[]
+  series?: BlogSeriesMetadata
 }
 
 type UnknownRecord = Record<string, unknown>
@@ -40,6 +47,26 @@ function readStringArray(record: UnknownRecord, key: string): string[] {
   return [...value]
 }
 
+function readSeries(record: UnknownRecord): BlogSeriesMetadata | undefined {
+  const value = record.series
+
+  if (value === undefined) return undefined
+
+  assertRecord(value, "MDX frontmatter series")
+
+  const order = value.order
+
+  if (!Number.isInteger(order) || Number(order) <= 0) {
+    throw new Error("MDX frontmatter series.order must be a positive integer")
+  }
+
+  return {
+    slug: readString(value, "slug"),
+    title: readString(value, "title"),
+    order: Number(order),
+  }
+}
+
 export function defineBlogMdxPost(
   attributes: unknown,
   expectedSlug: string,
@@ -54,6 +81,7 @@ export function defineBlogMdxPost(
     excerpt: readString(attributes, "excerpt"),
     tags: readStringArray(attributes, "tags"),
     relatedSlugs: readStringArray(attributes, "relatedSlugs"),
+    series: readSeries(attributes),
   }
 
   if (post.slug !== expectedSlug) {

--- a/app/content/blog-mdx.ts
+++ b/app/content/blog-mdx.ts
@@ -1,0 +1,82 @@
+export type BlogPostMetadata = {
+  slug: string
+  title: string
+  description: string
+  date: string
+  excerpt: string
+  tags: string[]
+  relatedSlugs: string[]
+}
+
+type UnknownRecord = Record<string, unknown>
+
+function assertRecord(value: unknown, label: string): asserts value is UnknownRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`)
+  }
+}
+
+function readString(record: UnknownRecord, key: string): string {
+  const value = record[key]
+
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`MDX frontmatter ${key} must be a non-empty string`)
+  }
+
+  return value
+}
+
+function readStringArray(record: UnknownRecord, key: string): string[] {
+  const value = record[key]
+
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    value.some((entry) => typeof entry !== "string" || entry.trim().length === 0)
+  ) {
+    throw new Error(`MDX frontmatter ${key} must be a non-empty string array`)
+  }
+
+  return [...value]
+}
+
+export function defineBlogMdxPost(
+  attributes: unknown,
+  expectedSlug: string,
+): BlogPostMetadata {
+  assertRecord(attributes, "MDX frontmatter")
+
+  const post: BlogPostMetadata = {
+    slug: readString(attributes, "slug"),
+    title: readString(attributes, "title"),
+    description: readString(attributes, "description"),
+    date: readString(attributes, "date"),
+    excerpt: readString(attributes, "excerpt"),
+    tags: readStringArray(attributes, "tags"),
+    relatedSlugs: readStringArray(attributes, "relatedSlugs"),
+  }
+
+  if (post.slug !== expectedSlug) {
+    throw new Error(
+      `MDX slug ${post.slug} does not match route slug ${expectedSlug}`,
+    )
+  }
+
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(post.date)) {
+    throw new Error(`MDX frontmatter date must use YYYY-MM-DD: ${post.date}`)
+  }
+
+  if (new Set(post.tags).size !== post.tags.length) {
+    throw new Error(`MDX frontmatter tags must be unique: ${post.slug}`)
+  }
+
+  if (new Set(post.relatedSlugs).size !== post.relatedSlugs.length) {
+    throw new Error(`MDX frontmatter relatedSlugs must be unique: ${post.slug}`)
+  }
+
+  if (post.relatedSlugs.includes(post.slug)) {
+    throw new Error(`MDX post cannot relate to itself: ${post.slug}`)
+  }
+
+  return post
+}

--- a/app/content/blog-mdx.ts
+++ b/app/content/blog-mdx.ts
@@ -17,7 +17,10 @@ export type BlogPostMetadata = {
 
 type UnknownRecord = Record<string, unknown>
 
-function assertRecord(value: unknown, label: string): asserts value is UnknownRecord {
+function assertRecord(
+  value: unknown,
+  label: string,
+): asserts value is UnknownRecord {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new Error(`${label} must be an object`)
   }
@@ -39,7 +42,9 @@ function readStringArray(record: UnknownRecord, key: string): string[] {
   if (
     !Array.isArray(value) ||
     value.length === 0 ||
-    value.some((entry) => typeof entry !== "string" || entry.trim().length === 0)
+    value.some(
+      (entry) => typeof entry !== "string" || entry.trim().length === 0,
+    )
   ) {
     throw new Error(`MDX frontmatter ${key} must be a non-empty string array`)
   }

--- a/app/content/blog-series-route.server.ts
+++ b/app/content/blog-series-route.server.ts
@@ -1,0 +1,66 @@
+import {
+  AI_PIPELINE_POST_SLUG,
+  aiPipelinePost,
+} from "~/content/ai-pipeline-post.server"
+import { getBlogSeriesBySlug } from "~/content/blog-series"
+
+export type BlogSeriesRouteData = {
+  series: {
+    slug: string
+    title: string
+    posts: {
+      slug: string
+      title: string
+      excerpt: string
+      date: string
+      order: number
+    }[]
+  }
+}
+
+export function getBlogSeriesRouteData(
+  slug: string,
+): BlogSeriesRouteData | null {
+  const series = getBlogSeriesBySlug(slug)
+
+  if (!series) return null
+
+  const posts = series.posts.map((legacyPost, index) => {
+    if (legacyPost.slug !== AI_PIPELINE_POST_SLUG) {
+      return {
+        slug: legacyPost.slug,
+        title: legacyPost.title,
+        excerpt: legacyPost.excerpt,
+        date: legacyPost.date,
+        order: index + 1,
+      }
+    }
+
+    if (
+      !aiPipelinePost.series ||
+      aiPipelinePost.series.slug !== series.slug ||
+      aiPipelinePost.series.title !== series.title ||
+      aiPipelinePost.series.order !== index + 1
+    ) {
+      throw new Error(
+        `MDX series metadata drifted for ${AI_PIPELINE_POST_SLUG}`,
+      )
+    }
+
+    return {
+      slug: aiPipelinePost.slug,
+      title: aiPipelinePost.title,
+      excerpt: aiPipelinePost.excerpt,
+      date: aiPipelinePost.date,
+      order: aiPipelinePost.series.order,
+    }
+  })
+
+  return {
+    series: {
+      slug: series.slug,
+      title: series.title,
+      posts,
+    },
+  }
+}

--- a/app/content/posts/ai-pipelines-need-control-boundaries.mdx
+++ b/app/content/posts/ai-pipelines-need-control-boundaries.mdx
@@ -1,132 +1,91 @@
 ---
 slug: ai-pipelines-need-control-boundaries
 title: AI Pipelines Need Control Boundaries
-description: Why AI-assisted workflows need explicit state ownership, validation gates, and a deterministic system of record.
-date: 2026-03-22
-excerpt: AI is useful inside a pipeline, but it should not own truth. Reliable systems keep AI behind explicit inputs, validation, and deterministic write boundaries.
+description: Enterprise AI should be treated as an untrusted reasoning component inside a governed integration path.
+date: 2026-04-24
+excerpt: Enterprise AI becomes safer and more useful when normalization, authorization, validation, and write-back controls are explicit around it.
 tags:
-  - ai
-  - architecture
-  - governance
-  - pipelines
+  - architecture-notes
+  - ai-governance
+  - workflow-validation
+  - secure-integration
 relatedSlugs:
   - secure-platform-integration-is-not-plumbing
   - software-layers-are-risk-boundaries
+series:
+  slug: architecture-control-boundaries
+  title: Architecture Control Boundaries
+  order: 2
 ---
 
-## AI is a reasoning component, not the system of record
+## Start with the right mental model
 
-AI can classify, summarize, recommend, transform, and draft. Those are useful capabilities, but none of them make a model a safe owner of durable state.
-
-A dependable AI-assisted workflow separates four responsibilities:
-
-1. **Input ownership** — authoritative systems provide bounded, versioned inputs.
-2. **Reasoning** — the model proposes an interpretation or candidate change.
-3. **Validation** — deterministic policy and schema checks decide whether the proposal is admissible.
-4. **Commit** — an owned service writes the accepted result and records evidence.
+Enterprise AI work becomes risky when the model is treated like an authoritative component instead of a fallible part of a larger delivery path.
 
 <Callout>
   <p>
-    AI is not the system of record. AI is an untrusted reasoning component inside
-    a governed delivery pipeline.
+    AI is not the system of record. AI is an untrusted reasoning component
+    operating inside a governed integration path.
   </p>
 </Callout>
 
-Without that boundary, model output quietly becomes application state. A plausible response can then overwrite durable truth without provenance, replayability, or a clear recovery path.
+That framing changes the design. Prompts, tool access, retrieval, outputs, and write-back actions all need control boundaries of their own.
 
-## A bounded pipeline
+## Pre-processing
 
-A minimal control boundary looks like this:
+Input control starts before a model sees anything. Raw enterprise data usually needs normalization to reduce ambiguity, redaction to remove material the model does not need, enrichment to provide stable business context, and provenance markers so downstream reviewers can see what sources shaped the result.
+
+- Normalize structure and terminology so prompts do not depend on unstable source formatting.
+- Redact sensitive fields when they are not necessary for the reasoning task.
+- Enrich with identifiers, policy context, and known workflow state.
+- Attach provenance so outputs can be inspected against real evidence.
+
+## MCP and tool boundary
+
+Tool access should be scoped like any other privileged interface. Exposing a broad tool surface because a model might find it useful is the wrong default. The model should receive only the tools, methods, and data slices required for the current workflow step.
+
+- Scope access to the task and actor, not the whole platform.
+- Require authorization at the tool boundary, not only in prompts.
+- Audit tool invocations and carry the calling workflow identity.
+- Treat MCP or similar tool channels as integration surfaces subject to the same control design as any other API.
+
+## AI execution
 
 <Figure
-  title="AI pipeline control boundary"
-  caption="Authoritative inputs flow through an untrusted reasoning step, deterministic validation, and an owned commit boundary."
-  src="/img/architecture/ai-pipeline-boundary.svg"
-  alt="Flow diagram from source systems through an AI reasoning component, validation gate, and deterministic system of record"
+  title="Governed AI pipeline"
+  caption="AI lives inside a controlled path with explicit checks before and after reasoning."
+  src="/img/blog/ai_pipeline_diagram.svg"
+  alt="Diagram showing sources flowing through preprocessing, MCP boundary, AI layer, post-processing, and finally to controlled targets."
+  narrow
 />
 
-The model never receives ambient authority to write directly. It produces a proposal with enough context for deterministic checks and human review where required.
+Inside the execution zone, retrieval, model or agent selection, and tool calls are still just intermediate reasoning steps. They are useful, but they should not be confused with final system action. There needs to be a visible boundary between the reasoning process and the transaction that changes a real workflow.
 
-| Stage | Owns | Must not own |
+This is where a layered architecture matters. The same separation described in <PostLink slug="software-layers-are-risk-boundaries">Software Layers Are Risk Boundaries</PostLink> keeps AI-specific logic from leaking directly into systems of record.
+
+## Post-processing and approval
+
+Before anything is written back, the result needs to be validated, scored, compared with expected structures, and, where necessary, held for approval. This is the difference between an assistant and an uncontrolled actor.
+
+- Validate schema, policy requirements, and required fields.
+- Score confidence or rule conformance using deterministic checks rather than model self-assessment alone.
+- Diff proposed changes against current records so reviewers can see the exact effect.
+- Require explicit approval when the action changes regulated workflow, status, or customer-visible records.
+
+## Controlled write-back
+
+The write-back step should look like a normal governed integration: authorized actor, validated payload, logged decision, and a durable trace of what was changed. If that control surface does not exist, the pipeline is not ready for enterprise use.
+
+## Threat and failure modes
+
+| Failure mode | What usually causes it | Control response |
 | --- | --- | --- |
-| Source adapter | Input retrieval, normalization, source version | Business decisions |
-| AI reasoning | Candidate interpretation or transformation | Durable state, credentials, policy |
-| Validation gate | Schema, policy, authorization, confidence thresholds | Open-ended reasoning |
-| Commit service | Idempotent writes, evidence, audit trail | Hidden model behavior |
+| Over-broad tool access | Convenience-driven integration and prompt-only policy | Scope tools by workflow, enforce authorization, audit calls |
+| Unverifiable output | Missing provenance and no deterministic validation | Attach sources, run schema checks, retain review traces |
+| Unsafe write-back | Model output sent directly to systems of record | Require approval gates and controlled adapter writes |
+| Prompt leakage of sensitive data | Skipping normalization and redaction upstream | Pre-process inputs and minimize exposed fields |
+| Workflow drift | AI-specific logic embedded in every consumer | Keep orchestration in an application boundary |
 
-## Make uncertainty explicit
+## Conclusion
 
-A model response should be treated as a typed proposal, not free-form truth. Useful output contracts include:
-
-- the requested operation;
-- source identifiers and versions;
-- a confidence or ambiguity signal;
-- cited evidence;
-- validation warnings;
-- an idempotency key;
-- the policy version used for evaluation.
-
-The pipeline can reject incomplete or stale proposals before they reach a write boundary. This is easier to reason about than asking downstream code to infer whether arbitrary prose is safe.
-
-## Preserve deterministic ownership
-
-The service that owns a domain should remain the only component allowed to commit its state. An AI workflow can request a change through the same public command surface used by other clients, but it should not bypass that surface.
-
-That rule preserves:
-
-- authorization and tenancy checks;
-- invariants and transactions;
-- idempotency;
-- audit and provenance;
-- retries and compensation;
-- operational observability.
-
-This is the same principle described in <PostLink slug="secure-platform-integration-is-not-plumbing">Secure Platform Integration Is Not Plumbing</PostLink>: integration code is part of the trust boundary, not incidental glue.
-
-## Fail closed at the boundary
-
-A bounded workflow needs explicit outcomes. For example:
-
-- **accepted** — validation passed and the commit completed;
-- **rejected** — policy or schema validation failed;
-- **review required** — ambiguity or impact crossed a configured threshold;
-- **stale** — source versions changed before commit;
-- **indeterminate** — dependencies failed and no write occurred.
-
-A timeout or malformed model response must not be interpreted as approval. Missing evidence must not silently lower the standard of proof.
-
-## Record enough evidence to replay the decision
-
-The operational record should include the input references, model and prompt identifiers, normalized proposal, validation results, approver decisions, commit result, and resulting state version.
-
-That record does not guarantee that a nondeterministic model will produce identical text later. It does make the delivered decision explainable and allows the deterministic parts of the pipeline to be replayed.
-
-## Keep the boundary visible
-
-AI pipelines become risky when their authority is hidden inside a convenience function, agent tool, or background task. The architecture should make the transition from suggestion to durable effect visible in code, telemetry, and review.
-
-<Callout>
-  <p>
-    The important boundary is not where the model is called. It is where a model
-    proposal becomes an authorized, durable effect.
-  </p>
-</Callout>
-
-Layering helps expose that transition. <PostLink slug="software-layers-are-risk-boundaries">Software Layers Are Risk Boundaries</PostLink> describes why each layer should narrow authority rather than merely rearrange code.
-
-## Practical review questions
-
-Before shipping an AI-assisted workflow, ask:
-
-- Which system owns each input?
-- What exact output schema can the model produce?
-- Which checks are deterministic?
-- What authority does the model process possess?
-- Who or what can approve a high-impact action?
-- Which service owns the final write?
-- Can retries create duplicate effects?
-- What evidence is retained?
-- Can operators distinguish rejection, failure, and uncertainty?
-- Can the workflow be disabled without corrupting core state?
-
-When those answers are explicit, AI remains a useful component. When they are implicit, the model becomes an accidental control plane.
+The practical goal is not to remove AI from the workflow. It is to put AI in a governed part of the workflow without letting it become the implicit owner of security, state, or business truth. Once the control boundaries are explicit, enterprise AI becomes easier to test, review, and replace.

--- a/app/content/posts/ai-pipelines-need-control-boundaries.mdx
+++ b/app/content/posts/ai-pipelines-need-control-boundaries.mdx
@@ -2,7 +2,7 @@
 slug: ai-pipelines-need-control-boundaries
 title: AI Pipelines Need Control Boundaries
 description: Enterprise AI should be treated as an untrusted reasoning component inside a governed integration path.
-date: 2026-04-24
+date: "2026-04-24"
 excerpt: Enterprise AI becomes safer and more useful when normalization, authorization, validation, and write-back controls are explicit around it.
 tags:
   - architecture-notes

--- a/app/content/posts/ai-pipelines-need-control-boundaries.mdx
+++ b/app/content/posts/ai-pipelines-need-control-boundaries.mdx
@@ -78,13 +78,13 @@ The write-back step should look like a normal governed integration: authorized a
 
 ## Threat and failure modes
 
-| Failure mode | What usually causes it | Control response |
-| --- | --- | --- |
-| Over-broad tool access | Convenience-driven integration and prompt-only policy | Scope tools by workflow, enforce authorization, audit calls |
-| Unverifiable output | Missing provenance and no deterministic validation | Attach sources, run schema checks, retain review traces |
-| Unsafe write-back | Model output sent directly to systems of record | Require approval gates and controlled adapter writes |
-| Prompt leakage of sensitive data | Skipping normalization and redaction upstream | Pre-process inputs and minimize exposed fields |
-| Workflow drift | AI-specific logic embedded in every consumer | Keep orchestration in an application boundary |
+| Failure mode                     | What usually causes it                                | Control response                                            |
+| -------------------------------- | ----------------------------------------------------- | ----------------------------------------------------------- |
+| Over-broad tool access           | Convenience-driven integration and prompt-only policy | Scope tools by workflow, enforce authorization, audit calls |
+| Unverifiable output              | Missing provenance and no deterministic validation    | Attach sources, run schema checks, retain review traces     |
+| Unsafe write-back                | Model output sent directly to systems of record       | Require approval gates and controlled adapter writes        |
+| Prompt leakage of sensitive data | Skipping normalization and redaction upstream         | Pre-process inputs and minimize exposed fields              |
+| Workflow drift                   | AI-specific logic embedded in every consumer          | Keep orchestration in an application boundary               |
 
 ## Conclusion
 

--- a/app/content/posts/ai-pipelines-need-control-boundaries.mdx
+++ b/app/content/posts/ai-pipelines-need-control-boundaries.mdx
@@ -1,0 +1,132 @@
+---
+slug: ai-pipelines-need-control-boundaries
+title: AI Pipelines Need Control Boundaries
+description: Why AI-assisted workflows need explicit state ownership, validation gates, and a deterministic system of record.
+date: 2026-03-22
+excerpt: AI is useful inside a pipeline, but it should not own truth. Reliable systems keep AI behind explicit inputs, validation, and deterministic write boundaries.
+tags:
+  - ai
+  - architecture
+  - governance
+  - pipelines
+relatedSlugs:
+  - secure-platform-integration-is-not-plumbing
+  - software-layers-are-risk-boundaries
+---
+
+## AI is a reasoning component, not the system of record
+
+AI can classify, summarize, recommend, transform, and draft. Those are useful capabilities, but none of them make a model a safe owner of durable state.
+
+A dependable AI-assisted workflow separates four responsibilities:
+
+1. **Input ownership** — authoritative systems provide bounded, versioned inputs.
+2. **Reasoning** — the model proposes an interpretation or candidate change.
+3. **Validation** — deterministic policy and schema checks decide whether the proposal is admissible.
+4. **Commit** — an owned service writes the accepted result and records evidence.
+
+<Callout>
+  <p>
+    AI is not the system of record. AI is an untrusted reasoning component inside
+    a governed delivery pipeline.
+  </p>
+</Callout>
+
+Without that boundary, model output quietly becomes application state. A plausible response can then overwrite durable truth without provenance, replayability, or a clear recovery path.
+
+## A bounded pipeline
+
+A minimal control boundary looks like this:
+
+<Figure
+  title="AI pipeline control boundary"
+  caption="Authoritative inputs flow through an untrusted reasoning step, deterministic validation, and an owned commit boundary."
+  src="/img/architecture/ai-pipeline-boundary.svg"
+  alt="Flow diagram from source systems through an AI reasoning component, validation gate, and deterministic system of record"
+/>
+
+The model never receives ambient authority to write directly. It produces a proposal with enough context for deterministic checks and human review where required.
+
+| Stage | Owns | Must not own |
+| --- | --- | --- |
+| Source adapter | Input retrieval, normalization, source version | Business decisions |
+| AI reasoning | Candidate interpretation or transformation | Durable state, credentials, policy |
+| Validation gate | Schema, policy, authorization, confidence thresholds | Open-ended reasoning |
+| Commit service | Idempotent writes, evidence, audit trail | Hidden model behavior |
+
+## Make uncertainty explicit
+
+A model response should be treated as a typed proposal, not free-form truth. Useful output contracts include:
+
+- the requested operation;
+- source identifiers and versions;
+- a confidence or ambiguity signal;
+- cited evidence;
+- validation warnings;
+- an idempotency key;
+- the policy version used for evaluation.
+
+The pipeline can reject incomplete or stale proposals before they reach a write boundary. This is easier to reason about than asking downstream code to infer whether arbitrary prose is safe.
+
+## Preserve deterministic ownership
+
+The service that owns a domain should remain the only component allowed to commit its state. An AI workflow can request a change through the same public command surface used by other clients, but it should not bypass that surface.
+
+That rule preserves:
+
+- authorization and tenancy checks;
+- invariants and transactions;
+- idempotency;
+- audit and provenance;
+- retries and compensation;
+- operational observability.
+
+This is the same principle described in <PostLink slug="secure-platform-integration-is-not-plumbing">Secure Platform Integration Is Not Plumbing</PostLink>: integration code is part of the trust boundary, not incidental glue.
+
+## Fail closed at the boundary
+
+A bounded workflow needs explicit outcomes. For example:
+
+- **accepted** — validation passed and the commit completed;
+- **rejected** — policy or schema validation failed;
+- **review required** — ambiguity or impact crossed a configured threshold;
+- **stale** — source versions changed before commit;
+- **indeterminate** — dependencies failed and no write occurred.
+
+A timeout or malformed model response must not be interpreted as approval. Missing evidence must not silently lower the standard of proof.
+
+## Record enough evidence to replay the decision
+
+The operational record should include the input references, model and prompt identifiers, normalized proposal, validation results, approver decisions, commit result, and resulting state version.
+
+That record does not guarantee that a nondeterministic model will produce identical text later. It does make the delivered decision explainable and allows the deterministic parts of the pipeline to be replayed.
+
+## Keep the boundary visible
+
+AI pipelines become risky when their authority is hidden inside a convenience function, agent tool, or background task. The architecture should make the transition from suggestion to durable effect visible in code, telemetry, and review.
+
+<Callout>
+  <p>
+    The important boundary is not where the model is called. It is where a model
+    proposal becomes an authorized, durable effect.
+  </p>
+</Callout>
+
+Layering helps expose that transition. <PostLink slug="software-layers-are-risk-boundaries">Software Layers Are Risk Boundaries</PostLink> describes why each layer should narrow authority rather than merely rearrange code.
+
+## Practical review questions
+
+Before shipping an AI-assisted workflow, ask:
+
+- Which system owns each input?
+- What exact output schema can the model produce?
+- Which checks are deterministic?
+- What authority does the model process possess?
+- Who or what can approve a high-impact action?
+- Which service owns the final write?
+- Can retries create duplicate effects?
+- What evidence is retained?
+- Can operators distinguish rejection, failure, and uncertainty?
+- Can the workflow be disabled without corrupting core state?
+
+When those answers are explicit, AI remains a useful component. When they are implicit, the model becomes an accidental control plane.

--- a/app/routes/blog.$slug.tsx
+++ b/app/routes/blog.$slug.tsx
@@ -1,20 +1,31 @@
 import type { LoaderFunctionArgs, MetaFunction } from "@remix-run/node"
 import { json } from "@remix-run/node"
-import { Link, useLoaderData } from "@remix-run/react"
-import { PageTitle } from "~/components"
-import { formatBlogDate } from "~/content/blog"
+import { useLoaderData } from "@remix-run/react"
+
+import {
+  BlogArticleLayout,
+  type BlogArticleSeriesNavigation,
+} from "~/components/blog-article-layout"
+import type { BlogPostMetadata } from "~/content/blog-mdx"
 import { getBlogPostBySlug, getRelatedPosts } from "~/content/blog-provider"
 import { getSeriesNavigation } from "~/content/blog-series"
 import { buildArticleMeta, buildArticleStructuredData } from "~/utils/seo"
 
 type LoaderData = {
-  post: {
-    slug: string
-    title: string
-    description: string
-    date: string
-    excerpt: string
-    tags: string[]
+  post: BlogPostMetadata
+  relatedPosts: BlogPostMetadata[]
+  seriesNavigation: BlogArticleSeriesNavigation | null
+}
+
+function toMetadata(candidate: BlogPostMetadata): BlogPostMetadata {
+  return {
+    slug: candidate.slug,
+    title: candidate.title,
+    description: candidate.description,
+    date: candidate.date,
+    excerpt: candidate.excerpt,
+    tags: [...candidate.tags],
+    relatedSlugs: [...candidate.relatedSlugs],
   }
 }
 
@@ -25,15 +36,25 @@ export async function loader({ params }: LoaderFunctionArgs) {
     throw new Response("Not Found", { status: 404 })
   }
 
+  const series = getSeriesNavigation(post)
+  const seriesNavigation = series
+    ? {
+        series: {
+          slug: series.series.slug,
+          title: series.series.title,
+        },
+        index: series.index,
+        total: series.total,
+        previous: series.previous ? toMetadata(series.previous) : null,
+        next: series.next ? toMetadata(series.next) : null,
+        posts: series.posts.map(toMetadata),
+      }
+    : null
+
   return json<LoaderData>({
-    post: {
-      slug: post.slug,
-      title: post.title,
-      description: post.description,
-      date: post.date,
-      excerpt: post.excerpt,
-      tags: post.tags,
-    },
+    post: toMetadata(post),
+    relatedPosts: getRelatedPosts(post).map(toMetadata),
+    seriesNavigation,
   })
 }
 
@@ -55,7 +76,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 }
 
 export const handle = {
-  structuredData: (data: LoaderData | undefined) => {
+  structuredData(data: LoaderData | undefined) {
     if (!data) return null
 
     return buildArticleStructuredData({
@@ -69,133 +90,22 @@ export const handle = {
 }
 
 export default function BlogPostRoute() {
-  const { post: postMeta } = useLoaderData<typeof loader>()
-  const post = getBlogPostBySlug(postMeta.slug)
+  const data = useLoaderData<typeof loader>()
+  const legacyPost = getBlogPostBySlug(data.post.slug)
 
-  if (!post) {
-    throw new Error(`Missing blog post for slug: ${postMeta.slug}`)
+  if (!legacyPost) {
+    throw new Error(`Legacy blog content is missing for ${data.post.slug}`)
   }
 
-  const relatedPosts = getRelatedPosts(post)
-  const seriesNavigation = getSeriesNavigation(post)
+  const Content = legacyPost.Content
 
   return (
-    <article className="space-y-10">
-      <div className="space-y-5">
-        <Link className="article-meta-link inline-flex text-sm" to="/blog">
-          Back to blog
-        </Link>
-        <PageTitle title={post.title} subtitle={post.description} />
-        <div className="article-meta-row flex flex-wrap items-center gap-x-4 gap-y-2">
-          <time dateTime={post.date}>{formatBlogDate(post.date)}</time>
-          <span aria-hidden="true">/</span>
-          <span>{post.tags.join(", ")}</span>
-        </div>
-        <p className="article-lead">{post.excerpt}</p>
-      </div>
-
-      {seriesNavigation ? (
-        <section className="max-w-3xl rounded-2xl border border-slate-200 bg-slate-50/80 px-5 py-5 shadow-[0_10px_24px_rgba(31,42,42,0.05)]">
-          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-            <div className="space-y-2">
-              <p className="meta-kicker">Series</p>
-              <h2 className="text-[1.25rem] font-semibold tracking-[-0.02em] text-slate-900">
-                <Link to={`/blog/series/${seriesNavigation.series.slug}`}>
-                  {seriesNavigation.series.title}
-                </Link>
-              </h2>
-              <p className="page-copy-sm">
-                Part {seriesNavigation.index + 1} of {seriesNavigation.total}
-              </p>
-            </div>
-            <nav
-              className="grid gap-2 text-sm md:min-w-[16rem]"
-              aria-label={`${seriesNavigation.series.title} series navigation`}
-            >
-              {seriesNavigation.previous ? (
-                <Link
-                  className="article-meta-link"
-                  to={`/blog/${seriesNavigation.previous.slug}`}
-                >
-                  Previous: {seriesNavigation.previous.title}
-                </Link>
-              ) : null}
-              {seriesNavigation.next ? (
-                <Link
-                  className="article-meta-link"
-                  to={`/blog/${seriesNavigation.next.slug}`}
-                >
-                  Next: {seriesNavigation.next.title}
-                </Link>
-              ) : null}
-            </nav>
-          </div>
-        </section>
-      ) : null}
-
-      <div className="article-prose">
-        <post.Content />
-      </div>
-
-      {seriesNavigation ? (
-        <section className="max-w-3xl space-y-4 border-t border-gray-200 pt-8">
-          <h2 className="text-[1.35rem] font-semibold tracking-[-0.02em] text-slate-900">
-            In this series
-          </h2>
-          <div className="grid gap-3">
-            {seriesNavigation.posts.map((seriesPost, index) => {
-              const isCurrent = seriesPost.slug === post.slug
-
-              return (
-                <Link
-                  key={seriesPost.slug}
-                  to={`/blog/${seriesPost.slug}`}
-                  aria-current={isCurrent ? "page" : undefined}
-                  className={
-                    isCurrent
-                      ? "rounded-2xl border border-slate-300 bg-white px-4 py-4 text-left text-base shadow-[0_10px_24px_rgba(31,42,42,0.08)]"
-                      : "rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-4 text-left text-base shadow-[0_10px_24px_rgba(31,42,42,0.05)] transition-colors hover:bg-white"
-                  }
-                >
-                  <span className="meta-kicker mb-1 block">
-                    Part {index + 1}
-                  </span>
-                  <span className="block text-[1.02rem] font-semibold leading-7 tracking-[-0.015em] text-slate-900">
-                    {seriesPost.title}
-                  </span>
-                  <span className="mt-2 block text-sm leading-7 text-slate-600">
-                    {seriesPost.excerpt}
-                  </span>
-                </Link>
-              )
-            })}
-          </div>
-        </section>
-      ) : null}
-
-      {relatedPosts.length > 0 ? (
-        <section className="max-w-3xl space-y-4 border-t border-gray-200 pt-8">
-          <h2 className="text-[1.35rem] font-semibold tracking-[-0.02em] text-slate-900">
-            Related notes
-          </h2>
-          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-            {relatedPosts.map((relatedPost) => (
-              <Link
-                key={relatedPost.slug}
-                to={`/blog/${relatedPost.slug}`}
-                className="rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-4 text-left text-base shadow-[0_10px_24px_rgba(31,42,42,0.05)] transition-colors hover:bg-white"
-              >
-                <span className="block text-[1.02rem] font-semibold leading-7 tracking-[-0.015em] text-slate-900">
-                  {relatedPost.title}
-                </span>
-                <span className="mt-2 block text-sm leading-7 text-slate-600">
-                  {relatedPost.excerpt}
-                </span>
-              </Link>
-            ))}
-          </div>
-        </section>
-      ) : null}
-    </article>
+    <BlogArticleLayout
+      post={data.post}
+      relatedPosts={data.relatedPosts}
+      seriesNavigation={data.seriesNavigation}
+    >
+      <Content />
+    </BlogArticleLayout>
   )
 }

--- a/app/routes/blog._index.tsx
+++ b/app/routes/blog._index.tsx
@@ -8,15 +8,12 @@ import {
   BLOG_TITLE,
   formatBlogDate,
 } from "~/content/blog-format"
-import {
-  defineBlogMdxPost,
-  type BlogPostMetadata,
-} from "~/content/blog-mdx"
+import { defineBlogMdxPost, type BlogPostMetadata } from "~/content/blog-mdx"
 import { getBlogPosts } from "~/content/blog-provider"
 import { getSeriesNavigation } from "~/content/blog-series"
+import { attributes as aiPipelineAttributes } from "~/content/posts/ai-pipelines-need-control-boundaries.mdx"
 import { cardStyles } from "~/utils/card-styles"
 import { buildCollectionPageStructuredData, buildPageMeta } from "~/utils/seo"
-import { attributes as aiPipelineAttributes } from "~/content/posts/ai-pipelines-need-control-boundaries.mdx"
 
 const MDX_SLUG = "ai-pipelines-need-control-boundaries"
 const aiPipelinePost = defineBlogMdxPost(aiPipelineAttributes, MDX_SLUG)

--- a/app/routes/blog._index.tsx
+++ b/app/routes/blog._index.tsx
@@ -4,19 +4,19 @@ import { Link, useLoaderData } from "@remix-run/react"
 
 import { Card, PageTitle } from "~/components"
 import {
+  AI_PIPELINE_POST_SLUG,
+  aiPipelinePost,
+} from "~/content/ai-pipeline-post.server"
+import {
   BLOG_DESCRIPTION,
   BLOG_TITLE,
   formatBlogDate,
 } from "~/content/blog-format"
-import { defineBlogMdxPost, type BlogPostMetadata } from "~/content/blog-mdx"
+import type { BlogPostMetadata } from "~/content/blog-mdx"
 import { getBlogPosts } from "~/content/blog-provider"
 import { getSeriesNavigation } from "~/content/blog-series"
-import { attributes as aiPipelineAttributes } from "~/content/posts/ai-pipelines-need-control-boundaries.mdx"
 import { cardStyles } from "~/utils/card-styles"
 import { buildCollectionPageStructuredData, buildPageMeta } from "~/utils/seo"
-
-const MDX_SLUG = "ai-pipelines-need-control-boundaries"
-const aiPipelinePost = defineBlogMdxPost(aiPipelineAttributes, MDX_SLUG)
 
 type BlogIndexPost = BlogPostMetadata & {
   series?: {
@@ -45,7 +45,7 @@ function toMetadata(candidate: BlogPostMetadata): BlogPostMetadata {
 
 export async function loader() {
   const posts = getBlogPosts().map((legacyPost) => {
-    if (legacyPost.slug === MDX_SLUG) {
+    if (legacyPost.slug === AI_PIPELINE_POST_SLUG) {
       return aiPipelinePost
     }
 

--- a/app/routes/blog._index.tsx
+++ b/app/routes/blog._index.tsx
@@ -1,15 +1,75 @@
 import type { MetaFunction } from "@remix-run/node"
-import { Link } from "@remix-run/react"
+import { json } from "@remix-run/node"
+import { Link, useLoaderData } from "@remix-run/react"
+
 import { Card, PageTitle } from "~/components"
-import { BLOG_DESCRIPTION, BLOG_TITLE, formatBlogDate } from "~/content/blog"
+import {
+  BLOG_DESCRIPTION,
+  BLOG_TITLE,
+  formatBlogDate,
+} from "~/content/blog-format"
+import {
+  defineBlogMdxPost,
+  type BlogPostMetadata,
+} from "~/content/blog-mdx"
 import { getBlogPosts } from "~/content/blog-provider"
 import { getSeriesNavigation } from "~/content/blog-series"
 import { cardStyles } from "~/utils/card-styles"
 import { buildCollectionPageStructuredData, buildPageMeta } from "~/utils/seo"
+import { attributes as aiPipelineAttributes } from "~/content/posts/ai-pipelines-need-control-boundaries.mdx"
 
-const posts = getBlogPosts()
+const MDX_SLUG = "ai-pipelines-need-control-boundaries"
+const aiPipelinePost = defineBlogMdxPost(aiPipelineAttributes, MDX_SLUG)
 
-export const meta: MetaFunction = () =>
+type BlogIndexPost = BlogPostMetadata & {
+  series?: {
+    slug: string
+    title: string
+    order: number
+  }
+}
+
+type LoaderData = {
+  posts: BlogIndexPost[]
+}
+
+function toMetadata(candidate: BlogPostMetadata): BlogPostMetadata {
+  return {
+    slug: candidate.slug,
+    title: candidate.title,
+    description: candidate.description,
+    date: candidate.date,
+    excerpt: candidate.excerpt,
+    tags: [...candidate.tags],
+    relatedSlugs: [...candidate.relatedSlugs],
+    series: candidate.series ? { ...candidate.series } : undefined,
+  }
+}
+
+export async function loader() {
+  const posts = getBlogPosts().map((legacyPost) => {
+    if (legacyPost.slug === MDX_SLUG) {
+      return aiPipelinePost
+    }
+
+    const series = getSeriesNavigation(legacyPost)
+
+    return {
+      ...toMetadata(legacyPost),
+      series: series
+        ? {
+            slug: series.series.slug,
+            title: series.series.title,
+            order: series.index + 1,
+          }
+        : undefined,
+    }
+  })
+
+  return json<LoaderData>({ posts })
+}
+
+export const meta: MetaFunction<typeof loader> = () =>
   buildPageMeta({
     title: "Blog",
     description: BLOG_DESCRIPTION,
@@ -17,19 +77,25 @@ export const meta: MetaFunction = () =>
   })
 
 export const handle = {
-  structuredData: buildCollectionPageStructuredData({
-    name: "Blog",
-    description: BLOG_DESCRIPTION,
-    path: "/blog",
-    items: posts.map((post) => ({
-      name: post.title,
-      description: post.description,
-      url: `https://micrantha.com/blog/${post.slug}`,
-    })),
-  }),
+  structuredData(data: LoaderData | undefined) {
+    if (!data) return null
+
+    return buildCollectionPageStructuredData({
+      name: "Blog",
+      description: BLOG_DESCRIPTION,
+      path: "/blog",
+      items: data.posts.map((post) => ({
+        name: post.title,
+        description: post.description,
+        url: `https://micrantha.com/blog/${post.slug}`,
+      })),
+    })
+  },
 }
 
 export default function BlogIndexRoute() {
+  const { posts } = useLoaderData<typeof loader>()
+
   return (
     <div className="space-y-10">
       <PageTitle title="Blog" subtitle={BLOG_DESCRIPTION} />
@@ -48,50 +114,46 @@ export default function BlogIndexRoute() {
       </section>
 
       <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-        {posts.map((post, index) => {
-          const seriesNavigation = getSeriesNavigation(post)
-
-          return (
-            <Card
-              key={post.slug}
-              title={post.title}
-              url={`/blog/${post.slug}`}
-              headingLevel={2}
-              className={
-                index % 3 === 0
-                  ? `${cardStyles.neutral} editorial-card`
-                  : index % 3 === 1
-                    ? `${cardStyles.blue} editorial-card`
-                    : `${cardStyles.green} editorial-card`
-              }
-            >
-              <>
-                {seriesNavigation ? (
-                  <div className="meta-kicker mb-3 flex flex-wrap items-center gap-1.5">
-                    <span
-                      className="rounded-full border border-slate-300 bg-white text-slate-600"
-                      style={{
-                        fontSize: "0.58rem",
-                        letterSpacing: "0.14em",
-                        lineHeight: 1,
-                        padding: "0.14rem 0.38rem",
-                      }}
-                    >
-                      Part {seriesNavigation.index + 1}
-                    </span>
-                    <span>{seriesNavigation.series.title}</span>
-                  </div>
-                ) : null}
-                <span className="meta-kicker mb-3 block">
-                  {formatBlogDate(post.date)}
-                </span>
-                <span className="block text-[1.02rem] leading-8 text-slate-700">
-                  {post.excerpt}
-                </span>
-              </>
-            </Card>
-          )
-        })}
+        {posts.map((post, index) => (
+          <Card
+            key={post.slug}
+            title={post.title}
+            url={`/blog/${post.slug}`}
+            headingLevel={2}
+            className={
+              index % 3 === 0
+                ? `${cardStyles.neutral} editorial-card`
+                : index % 3 === 1
+                  ? `${cardStyles.blue} editorial-card`
+                  : `${cardStyles.green} editorial-card`
+            }
+          >
+            <>
+              {post.series ? (
+                <div className="meta-kicker mb-3 flex flex-wrap items-center gap-1.5">
+                  <span
+                    className="rounded-full border border-slate-300 bg-white text-slate-600"
+                    style={{
+                      fontSize: "0.58rem",
+                      letterSpacing: "0.14em",
+                      lineHeight: 1,
+                      padding: "0.14rem 0.38rem",
+                    }}
+                  >
+                    Part {post.series.order}
+                  </span>
+                  <span>{post.series.title}</span>
+                </div>
+              ) : null}
+              <span className="meta-kicker mb-3 block">
+                {formatBlogDate(post.date)}
+              </span>
+              <span className="block text-[1.02rem] leading-8 text-slate-700">
+                {post.excerpt}
+              </span>
+            </>
+          </Card>
+        ))}
       </section>
 
       <section className="editorial-panel max-w-3xl space-y-4 bg-slate-50/80 px-6 py-6">

--- a/app/routes/blog._index.tsx
+++ b/app/routes/blog._index.tsx
@@ -4,66 +4,23 @@ import { Link, useLoaderData } from "@remix-run/react"
 
 import { Card, PageTitle } from "~/components"
 import {
-  AI_PIPELINE_POST_SLUG,
-  aiPipelinePost,
-} from "~/content/ai-pipeline-post.server"
-import {
   BLOG_DESCRIPTION,
   BLOG_TITLE,
   formatBlogDate,
 } from "~/content/blog-format"
-import type { BlogPostMetadata } from "~/content/blog-mdx"
-import { getBlogPosts } from "~/content/blog-provider"
-import { getSeriesNavigation } from "~/content/blog-series"
+import {
+  getBlogIndexPosts,
+  type BlogIndexPost,
+} from "~/content/blog-index.server"
 import { cardStyles } from "~/utils/card-styles"
 import { buildCollectionPageStructuredData, buildPageMeta } from "~/utils/seo"
-
-type BlogIndexPost = BlogPostMetadata & {
-  series?: {
-    slug: string
-    title: string
-    order: number
-  }
-}
 
 type LoaderData = {
   posts: BlogIndexPost[]
 }
 
-function toMetadata(candidate: BlogPostMetadata): BlogPostMetadata {
-  return {
-    slug: candidate.slug,
-    title: candidate.title,
-    description: candidate.description,
-    date: candidate.date,
-    excerpt: candidate.excerpt,
-    tags: [...candidate.tags],
-    relatedSlugs: [...candidate.relatedSlugs],
-    series: candidate.series ? { ...candidate.series } : undefined,
-  }
-}
-
 export async function loader() {
-  const posts = getBlogPosts().map((legacyPost) => {
-    if (legacyPost.slug === AI_PIPELINE_POST_SLUG) {
-      return aiPipelinePost
-    }
-
-    const series = getSeriesNavigation(legacyPost)
-
-    return {
-      ...toMetadata(legacyPost),
-      series: series
-        ? {
-            slug: series.series.slug,
-            title: series.series.title,
-            order: series.index + 1,
-          }
-        : undefined,
-    }
-  })
-
-  return json<LoaderData>({ posts })
+  return json<LoaderData>({ posts: getBlogIndexPosts() })
 }
 
 export const meta: MetaFunction<typeof loader> = () =>

--- a/app/routes/blog.ai-pipelines-need-control-boundaries.tsx
+++ b/app/routes/blog.ai-pipelines-need-control-boundaries.tsx
@@ -1,0 +1,124 @@
+import type { LoaderFunctionArgs, MetaFunction } from "@remix-run/node"
+import { json } from "@remix-run/node"
+import { useLoaderData } from "@remix-run/react"
+
+import {
+  BlogArticleLayout,
+  type BlogArticleSeriesNavigation,
+} from "~/components/blog-article-layout"
+import { blogMdxComponents } from "~/components/blog-mdx-components"
+import {
+  defineBlogMdxPost,
+  type BlogPostMetadata,
+} from "~/content/blog-mdx"
+import { getBlogPostBySlug, getRelatedPosts } from "~/content/blog-provider"
+import { getSeriesNavigation } from "~/content/blog-series"
+import ArticleContent, {
+  attributes,
+} from "~/content/posts/ai-pipelines-need-control-boundaries.mdx"
+import { buildArticleMeta, buildArticleStructuredData } from "~/utils/seo"
+
+const SLUG = "ai-pipelines-need-control-boundaries"
+const post = defineBlogMdxPost(attributes, SLUG)
+
+type LoaderData = {
+  post: BlogPostMetadata
+  relatedPosts: BlogPostMetadata[]
+  seriesNavigation: BlogArticleSeriesNavigation | null
+}
+
+function toMetadata(candidate: BlogPostMetadata): BlogPostMetadata {
+  return {
+    slug: candidate.slug,
+    title: candidate.title,
+    description: candidate.description,
+    date: candidate.date,
+    excerpt: candidate.excerpt,
+    tags: [...candidate.tags],
+    relatedSlugs: [...candidate.relatedSlugs],
+  }
+}
+
+function assertLegacyMetadataMatchesMdx(legacyPost: BlogPostMetadata) {
+  const comparableLegacy = toMetadata(legacyPost)
+
+  if (JSON.stringify(comparableLegacy) !== JSON.stringify(post)) {
+    throw new Error(`Legacy metadata drifted from MDX frontmatter for ${SLUG}`)
+  }
+}
+
+export async function loader(_args: LoaderFunctionArgs) {
+  const legacyPost = getBlogPostBySlug(SLUG)
+
+  if (!legacyPost) {
+    throw new Response("MDX compatibility metadata is missing", { status: 500 })
+  }
+
+  assertLegacyMetadataMatchesMdx(legacyPost)
+
+  const series = getSeriesNavigation(legacyPost)
+  const seriesNavigation = series
+    ? {
+        series: {
+          slug: series.series.slug,
+          title: series.series.title,
+        },
+        index: series.index,
+        total: series.total,
+        previous: series.previous ? toMetadata(series.previous) : null,
+        next: series.next ? toMetadata(series.next) : null,
+        posts: series.posts.map(toMetadata),
+      }
+    : null
+
+  return json<LoaderData>({
+    post,
+    relatedPosts: getRelatedPosts(legacyPost).map(toMetadata),
+    seriesNavigation,
+  })
+}
+
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  if (!data) {
+    return [
+      { title: "Blog post not found" },
+      { name: "robots", content: "noindex" },
+    ]
+  }
+
+  return buildArticleMeta({
+    title: data.post.title,
+    description: data.post.description,
+    path: `/blog/${data.post.slug}`,
+    publishedTime: data.post.date,
+    tags: data.post.tags,
+  })
+}
+
+export const handle = {
+  structuredData(data: LoaderData | undefined) {
+    if (!data) return null
+
+    return buildArticleStructuredData({
+      title: data.post.title,
+      description: data.post.description,
+      path: `/blog/${data.post.slug}`,
+      datePublished: data.post.date,
+      keywords: data.post.tags,
+    })
+  },
+}
+
+export default function AiPipelinesNeedControlBoundariesRoute() {
+  const data = useLoaderData<typeof loader>()
+
+  return (
+    <BlogArticleLayout
+      post={data.post}
+      relatedPosts={data.relatedPosts}
+      seriesNavigation={data.seriesNavigation}
+    >
+      <ArticleContent components={blogMdxComponents} />
+    </BlogArticleLayout>
+  )
+}

--- a/app/routes/blog.ai-pipelines-need-control-boundaries.tsx
+++ b/app/routes/blog.ai-pipelines-need-control-boundaries.tsx
@@ -7,10 +7,7 @@ import {
   type BlogArticleSeriesNavigation,
 } from "~/components/blog-article-layout"
 import { blogMdxComponents } from "~/components/blog-mdx-components"
-import {
-  defineBlogMdxPost,
-  type BlogPostMetadata,
-} from "~/content/blog-mdx"
+import { defineBlogMdxPost, type BlogPostMetadata } from "~/content/blog-mdx"
 import { getBlogPostBySlug } from "~/content/blog-provider"
 import { getSeriesNavigation } from "~/content/blog-series"
 import ArticleContent, {

--- a/app/routes/blog.ai-pipelines-need-control-boundaries.tsx
+++ b/app/routes/blog.ai-pipelines-need-control-boundaries.tsx
@@ -2,110 +2,19 @@ import type { MetaFunction } from "@remix-run/node"
 import { json } from "@remix-run/node"
 import { useLoaderData } from "@remix-run/react"
 
-import {
-  BlogArticleLayout,
-  type BlogArticleSeriesNavigation,
-} from "~/components/blog-article-layout"
+import { BlogArticleLayout } from "~/components/blog-article-layout"
 import { blogMdxComponents } from "~/components/blog-mdx-components"
-import { defineBlogMdxPost, type BlogPostMetadata } from "~/content/blog-mdx"
-import { getBlogPostBySlug } from "~/content/blog-provider"
-import { getSeriesNavigation } from "~/content/blog-series"
-import ArticleContent, {
-  attributes,
-} from "~/content/posts/ai-pipelines-need-control-boundaries.mdx"
+import {
+  getAiPipelineRouteData,
+  type AiPipelineRouteData,
+} from "~/content/ai-pipeline-route.server"
+import ArticleContent from "~/content/posts/ai-pipelines-need-control-boundaries.mdx"
 import { buildArticleMeta, buildArticleStructuredData } from "~/utils/seo"
 
-const SLUG = "ai-pipelines-need-control-boundaries"
-const post = defineBlogMdxPost(attributes, SLUG)
-
-type LoaderData = {
-  post: BlogPostMetadata
-  relatedPosts: BlogPostMetadata[]
-  seriesNavigation: BlogArticleSeriesNavigation | null
-}
-
-function toMetadata(candidate: BlogPostMetadata): BlogPostMetadata {
-  return {
-    slug: candidate.slug,
-    title: candidate.title,
-    description: candidate.description,
-    date: candidate.date,
-    excerpt: candidate.excerpt,
-    tags: [...candidate.tags],
-    relatedSlugs: [...candidate.relatedSlugs],
-    series: candidate.series ? { ...candidate.series } : undefined,
-  }
-}
-
-function comparableMetadata(candidate: BlogPostMetadata) {
-  const metadata = toMetadata(candidate)
-
-  delete metadata.series
-
-  return metadata
-}
-
-function assertLegacyMetadataMatchesMdx(legacyPost: BlogPostMetadata) {
-  if (
-    JSON.stringify(comparableMetadata(legacyPost)) !==
-    JSON.stringify(comparableMetadata(post))
-  ) {
-    throw new Error(`Legacy metadata drifted from MDX frontmatter for ${SLUG}`)
-  }
-}
-
-function resolveRelatedPosts() {
-  return post.relatedSlugs.map((slug) => {
-    const relatedPost = getBlogPostBySlug(slug)
-
-    if (!relatedPost) {
-      throw new Error(`MDX related post does not exist: ${slug}`)
-    }
-
-    return toMetadata(relatedPost)
-  })
-}
+type LoaderData = AiPipelineRouteData
 
 export async function loader() {
-  const legacyPost = getBlogPostBySlug(SLUG)
-
-  if (!legacyPost) {
-    throw new Response("MDX compatibility metadata is missing", { status: 500 })
-  }
-
-  assertLegacyMetadataMatchesMdx(legacyPost)
-
-  const series = getSeriesNavigation(legacyPost)
-
-  if (!series || !post.series) {
-    throw new Error(`MDX series metadata is missing for ${SLUG}`)
-  }
-
-  if (
-    post.series.slug !== series.series.slug ||
-    post.series.title !== series.series.title ||
-    post.series.order !== series.index + 1
-  ) {
-    throw new Error(`MDX series metadata drifted for ${SLUG}`)
-  }
-
-  return json<LoaderData>({
-    post,
-    relatedPosts: resolveRelatedPosts(),
-    seriesNavigation: {
-      series: {
-        slug: post.series.slug,
-        title: post.series.title,
-      },
-      index: post.series.order - 1,
-      total: series.total,
-      previous: series.previous ? toMetadata(series.previous) : null,
-      next: series.next ? toMetadata(series.next) : null,
-      posts: series.posts.map((seriesPost) =>
-        seriesPost.slug === SLUG ? post : toMetadata(seriesPost),
-      ),
-    },
-  })
+  return json<LoaderData>(getAiPipelineRouteData())
 }
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {

--- a/app/routes/blog.ai-pipelines-need-control-boundaries.tsx
+++ b/app/routes/blog.ai-pipelines-need-control-boundaries.tsx
@@ -1,4 +1,4 @@
-import type { LoaderFunctionArgs, MetaFunction } from "@remix-run/node"
+import type { MetaFunction } from "@remix-run/node"
 import { json } from "@remix-run/node"
 import { useLoaderData } from "@remix-run/react"
 
@@ -11,7 +11,7 @@ import {
   defineBlogMdxPost,
   type BlogPostMetadata,
 } from "~/content/blog-mdx"
-import { getBlogPostBySlug, getRelatedPosts } from "~/content/blog-provider"
+import { getBlogPostBySlug } from "~/content/blog-provider"
 import { getSeriesNavigation } from "~/content/blog-series"
 import ArticleContent, {
   attributes,
@@ -36,18 +36,40 @@ function toMetadata(candidate: BlogPostMetadata): BlogPostMetadata {
     excerpt: candidate.excerpt,
     tags: [...candidate.tags],
     relatedSlugs: [...candidate.relatedSlugs],
+    series: candidate.series ? { ...candidate.series } : undefined,
   }
 }
 
-function assertLegacyMetadataMatchesMdx(legacyPost: BlogPostMetadata) {
-  const comparableLegacy = toMetadata(legacyPost)
+function comparableMetadata(candidate: BlogPostMetadata) {
+  const metadata = toMetadata(candidate)
 
-  if (JSON.stringify(comparableLegacy) !== JSON.stringify(post)) {
+  delete metadata.series
+
+  return metadata
+}
+
+function assertLegacyMetadataMatchesMdx(legacyPost: BlogPostMetadata) {
+  if (
+    JSON.stringify(comparableMetadata(legacyPost)) !==
+    JSON.stringify(comparableMetadata(post))
+  ) {
     throw new Error(`Legacy metadata drifted from MDX frontmatter for ${SLUG}`)
   }
 }
 
-export async function loader(_args: LoaderFunctionArgs) {
+function resolveRelatedPosts() {
+  return post.relatedSlugs.map((slug) => {
+    const relatedPost = getBlogPostBySlug(slug)
+
+    if (!relatedPost) {
+      throw new Error(`MDX related post does not exist: ${slug}`)
+    }
+
+    return toMetadata(relatedPost)
+  })
+}
+
+export async function loader() {
   const legacyPost = getBlogPostBySlug(SLUG)
 
   if (!legacyPost) {
@@ -57,24 +79,35 @@ export async function loader(_args: LoaderFunctionArgs) {
   assertLegacyMetadataMatchesMdx(legacyPost)
 
   const series = getSeriesNavigation(legacyPost)
-  const seriesNavigation = series
-    ? {
-        series: {
-          slug: series.series.slug,
-          title: series.series.title,
-        },
-        index: series.index,
-        total: series.total,
-        previous: series.previous ? toMetadata(series.previous) : null,
-        next: series.next ? toMetadata(series.next) : null,
-        posts: series.posts.map(toMetadata),
-      }
-    : null
+
+  if (!series || !post.series) {
+    throw new Error(`MDX series metadata is missing for ${SLUG}`)
+  }
+
+  if (
+    post.series.slug !== series.series.slug ||
+    post.series.title !== series.series.title ||
+    post.series.order !== series.index + 1
+  ) {
+    throw new Error(`MDX series metadata drifted for ${SLUG}`)
+  }
 
   return json<LoaderData>({
     post,
-    relatedPosts: getRelatedPosts(legacyPost).map(toMetadata),
-    seriesNavigation,
+    relatedPosts: resolveRelatedPosts(),
+    seriesNavigation: {
+      series: {
+        slug: post.series.slug,
+        title: post.series.title,
+      },
+      index: post.series.order - 1,
+      total: series.total,
+      previous: series.previous ? toMetadata(series.previous) : null,
+      next: series.next ? toMetadata(series.next) : null,
+      posts: series.posts.map((seriesPost) =>
+        seriesPost.slug === SLUG ? post : toMetadata(seriesPost),
+      ),
+    },
   })
 }
 
@@ -90,7 +123,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
     title: data.post.title,
     description: data.post.description,
     path: `/blog/${data.post.slug}`,
-    publishedTime: data.post.date,
+    publishedTime: `${data.post.date}T00:00:00Z`,
     tags: data.post.tags,
   })
 }
@@ -103,7 +136,7 @@ export const handle = {
       title: data.post.title,
       description: data.post.description,
       path: `/blog/${data.post.slug}`,
-      datePublished: data.post.date,
+      datePublished: `${data.post.date}T00:00:00Z`,
       keywords: data.post.tags,
     })
   },

--- a/app/routes/blog.series.$slug.tsx
+++ b/app/routes/blog.series.$slug.tsx
@@ -3,15 +3,14 @@ import { json } from "@remix-run/node"
 import { Link, useLoaderData } from "@remix-run/react"
 
 import { Card, PageTitle } from "~/components"
+import {
+  AI_PIPELINE_POST_SLUG,
+  aiPipelinePost,
+} from "~/content/ai-pipeline-post.server"
 import { formatBlogDate } from "~/content/blog-format"
-import { defineBlogMdxPost } from "~/content/blog-mdx"
 import { getBlogSeriesBySlug } from "~/content/blog-series"
-import { attributes as aiPipelineAttributes } from "~/content/posts/ai-pipelines-need-control-boundaries.mdx"
 import { cardStyles } from "~/utils/card-styles"
 import { buildPageMeta } from "~/utils/seo"
-
-const MDX_SLUG = "ai-pipelines-need-control-boundaries"
-const aiPipelinePost = defineBlogMdxPost(aiPipelineAttributes, MDX_SLUG)
 
 type LoaderData = {
   series: {
@@ -35,7 +34,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
   }
 
   const posts = series.posts.map((legacyPost, index) => {
-    if (legacyPost.slug !== MDX_SLUG) {
+    if (legacyPost.slug !== AI_PIPELINE_POST_SLUG) {
       return {
         slug: legacyPost.slug,
         title: legacyPost.title,
@@ -51,7 +50,9 @@ export async function loader({ params }: LoaderFunctionArgs) {
       aiPipelinePost.series.title !== series.title ||
       aiPipelinePost.series.order !== index + 1
     ) {
-      throw new Error(`MDX series metadata drifted for ${MDX_SLUG}`)
+      throw new Error(
+        `MDX series metadata drifted for ${AI_PIPELINE_POST_SLUG}`,
+      )
     }
 
     return {

--- a/app/routes/blog.series.$slug.tsx
+++ b/app/routes/blog.series.$slug.tsx
@@ -3,74 +3,24 @@ import { json } from "@remix-run/node"
 import { Link, useLoaderData } from "@remix-run/react"
 
 import { Card, PageTitle } from "~/components"
-import {
-  AI_PIPELINE_POST_SLUG,
-  aiPipelinePost,
-} from "~/content/ai-pipeline-post.server"
 import { formatBlogDate } from "~/content/blog-format"
-import { getBlogSeriesBySlug } from "~/content/blog-series"
+import {
+  getBlogSeriesRouteData,
+  type BlogSeriesRouteData,
+} from "~/content/blog-series-route.server"
 import { cardStyles } from "~/utils/card-styles"
 import { buildPageMeta } from "~/utils/seo"
 
-type LoaderData = {
-  series: {
-    slug: string
-    title: string
-    posts: {
-      slug: string
-      title: string
-      excerpt: string
-      date: string
-      order: number
-    }[]
-  }
-}
+type LoaderData = BlogSeriesRouteData
 
 export async function loader({ params }: LoaderFunctionArgs) {
-  const series = getBlogSeriesBySlug(params.slug ?? "")
+  const data = getBlogSeriesRouteData(params.slug ?? "")
 
-  if (!series) {
+  if (!data) {
     throw new Response("Not Found", { status: 404 })
   }
 
-  const posts = series.posts.map((legacyPost, index) => {
-    if (legacyPost.slug !== AI_PIPELINE_POST_SLUG) {
-      return {
-        slug: legacyPost.slug,
-        title: legacyPost.title,
-        excerpt: legacyPost.excerpt,
-        date: legacyPost.date,
-        order: index + 1,
-      }
-    }
-
-    if (
-      !aiPipelinePost.series ||
-      aiPipelinePost.series.slug !== series.slug ||
-      aiPipelinePost.series.title !== series.title ||
-      aiPipelinePost.series.order !== index + 1
-    ) {
-      throw new Error(
-        `MDX series metadata drifted for ${AI_PIPELINE_POST_SLUG}`,
-      )
-    }
-
-    return {
-      slug: aiPipelinePost.slug,
-      title: aiPipelinePost.title,
-      excerpt: aiPipelinePost.excerpt,
-      date: aiPipelinePost.date,
-      order: aiPipelinePost.series.order,
-    }
-  })
-
-  return json<LoaderData>({
-    series: {
-      slug: series.slug,
-      title: series.title,
-      posts,
-    },
-  })
+  return json<LoaderData>(data)
 }
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {

--- a/app/routes/blog.series.$slug.tsx
+++ b/app/routes/blog.series.$slug.tsx
@@ -1,11 +1,17 @@
 import type { LoaderFunctionArgs, MetaFunction } from "@remix-run/node"
 import { json } from "@remix-run/node"
 import { Link, useLoaderData } from "@remix-run/react"
+
 import { Card, PageTitle } from "~/components"
-import { formatBlogDate } from "~/content/blog"
+import { formatBlogDate } from "~/content/blog-format"
+import { defineBlogMdxPost } from "~/content/blog-mdx"
 import { getBlogSeriesBySlug } from "~/content/blog-series"
+import { attributes as aiPipelineAttributes } from "~/content/posts/ai-pipelines-need-control-boundaries.mdx"
 import { cardStyles } from "~/utils/card-styles"
 import { buildPageMeta } from "~/utils/seo"
+
+const MDX_SLUG = "ai-pipelines-need-control-boundaries"
+const aiPipelinePost = defineBlogMdxPost(aiPipelineAttributes, MDX_SLUG)
 
 type LoaderData = {
   series: {
@@ -16,7 +22,7 @@ type LoaderData = {
       title: string
       excerpt: string
       date: string
-      order?: number
+      order: number
     }[]
   }
 }
@@ -28,16 +34,40 @@ export async function loader({ params }: LoaderFunctionArgs) {
     throw new Response("Not Found", { status: 404 })
   }
 
+  const posts = series.posts.map((legacyPost, index) => {
+    if (legacyPost.slug !== MDX_SLUG) {
+      return {
+        slug: legacyPost.slug,
+        title: legacyPost.title,
+        excerpt: legacyPost.excerpt,
+        date: legacyPost.date,
+        order: index + 1,
+      }
+    }
+
+    if (
+      !aiPipelinePost.series ||
+      aiPipelinePost.series.slug !== series.slug ||
+      aiPipelinePost.series.title !== series.title ||
+      aiPipelinePost.series.order !== index + 1
+    ) {
+      throw new Error(`MDX series metadata drifted for ${MDX_SLUG}`)
+    }
+
+    return {
+      slug: aiPipelinePost.slug,
+      title: aiPipelinePost.title,
+      excerpt: aiPipelinePost.excerpt,
+      date: aiPipelinePost.date,
+      order: aiPipelinePost.series.order,
+    }
+  })
+
   return json<LoaderData>({
     series: {
       slug: series.slug,
       title: series.title,
-      posts: series.posts.map((post) => ({
-        slug: post.slug,
-        title: post.title,
-        excerpt: post.excerpt,
-        date: post.date,
-      })),
+      posts,
     },
   })
 }
@@ -48,9 +78,9 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
   }
 
   return buildPageMeta({
-    title: data.series.title + " Series",
-    description: "Posts in the " + data.series.title + " series.",
-    path: "/blog/series/" + data.series.slug,
+    title: `${data.series.title} Series`,
+    description: `Posts in the ${data.series.title} series.`,
+    path: `/blog/series/${data.series.slug}`,
   })
 }
 
@@ -74,19 +104,19 @@ export default function BlogSeriesRoute() {
           <Card
             key={post.slug}
             title={post.title}
-            url={"/blog/" + post.slug}
+            url={`/blog/${post.slug}`}
             headingLevel={2}
             className={
               index % 3 === 0
-                ? cardStyles.neutral + " editorial-card"
+                ? `${cardStyles.neutral} editorial-card`
                 : index % 3 === 1
-                  ? cardStyles.blue + " editorial-card"
-                  : cardStyles.green + " editorial-card"
+                  ? `${cardStyles.blue} editorial-card`
+                  : `${cardStyles.green} editorial-card`
             }
           >
             <>
               <span className="meta-kicker mb-3 block">
-                Part {index + 1} / {formatBlogDate(post.date)}
+                Part {post.order} / {formatBlogDate(post.date)}
               </span>
               <span className="block text-[1.02rem] leading-8 text-slate-700">
                 {post.excerpt}

--- a/docs/content/blog-mdx.md
+++ b/docs/content/blog-mdx.md
@@ -1,0 +1,151 @@
+# Blog MDX Authoring and Migration
+
+## Status
+
+The blog is migrating incrementally from TSX-backed article bodies to declarative MDX. The first representative route is:
+
+```text
+/blog/ai-pipelines-need-control-boundaries
+```
+
+The migration deliberately keeps legacy posts working while each article moves through the same validated vertical slice.
+
+## File pattern
+
+Each migrated article has two files:
+
+```text
+app/content/posts/<slug>.mdx
+app/routes/blog.<slug>.tsx
+```
+
+The MDX file is the canonical article source. It owns frontmatter and body content.
+
+The static route wrapper owns Remix behavior:
+
+- loader data;
+- SEO metadata;
+- JSON-LD;
+- frontmatter validation;
+- related-post and series resolution;
+- the shared article layout;
+- the allow-listed MDX component map.
+
+Do not put Remix loaders, actions, headers, environment access, or route exports in the MDX file.
+
+## Frontmatter
+
+Use this shape:
+
+```yaml
+---
+slug: example-article
+title: Example Article
+description: A concise search and social description.
+date: "2026-08-03"
+excerpt: A short index-card summary.
+tags:
+  - architecture-notes
+  - example
+relatedSlugs:
+  - another-article
+series:
+  slug: example-series
+  title: Example Series
+  order: 2
+---
+```
+
+Rules enforced by `defineBlogMdxPost`:
+
+- `slug`, `title`, `description`, `date`, and `excerpt` are non-empty strings;
+- dates use quoted `YYYY-MM-DD` strings so YAML does not coerce them into `Date` objects;
+- tags and related slugs are non-empty, unique string arrays;
+- an article cannot relate to itself;
+- series order is a positive integer;
+- the frontmatter slug must match the static route slug.
+
+During the incremental migration, the server-side compatibility layer also fails when migrated metadata or series placement diverges from the legacy catalog.
+
+## Allowed article components
+
+The current component map is intentionally small:
+
+- `Callout` for a highlighted key point;
+- `Figure` for an image, title, caption, and accessible alternative text;
+- `PostLink` for an internal blog link by slug.
+
+Example:
+
+```mdx
+<Callout>
+  <p>A bounded statement.</p>
+</Callout>
+
+<Figure
+  title="Control boundary"
+  caption="A concise explanation."
+  src="/img/blog/example.svg"
+  alt="Accessible description of the diagram"
+/>
+
+See <PostLink slug="another-article">Another Article</PostLink>.
+```
+
+Prefer Markdown headings, paragraphs, lists, tables, emphasis, and links. Add a component to the shared map only when multiple articles need a stable semantic pattern. Do not create article-specific React components for ordinary prose.
+
+## Server-only metadata assembly
+
+Index, series, related-post, and transitional catalog resolution belong in `.server.ts` modules. Browser route modules receive serializable loader data only.
+
+This boundary matters because the legacy catalog still contains TSX bodies. Importing it directly from an index or static article route can cause esbuild to share unrelated article bodies with that route's browser chunk.
+
+The required `test:mdx:build` contract inspects the emitted Remix manifest and eager import closure. It verifies:
+
+- the migrated body is present in its static article route;
+- the migrated body is absent from the blog index route;
+- a known unrelated legacy article body is absent from both closures.
+
+## Validation
+
+Run the complete local sequence:
+
+```sh
+yarn install --frozen-lockfile --non-interactive
+yarn format:check
+yarn lint
+yarn typecheck
+yarn build
+yarn test:mdx:build
+yarn test:e2e e2e/mdx.spec.ts
+yarn cloudflare:functions:build
+yarn test:cloudflare:bundle-budget
+yarn test:cloudflare:adapter
+yarn test:cloudflare:runtime
+```
+
+The JavaScript-disabled Playwright test proves that the article heading, prose, figure, and internal links are present in server-rendered HTML before hydration.
+
+The source-isolated Cloudflare runtime contract proves that the compiled article runs from staged static assets and the prebuilt Worker without source MDX, TSX, `node_modules`, or compiler packages at request time.
+
+## Migrating another article
+
+1. Copy the existing published metadata and body without rewriting it.
+2. Create `app/content/posts/<slug>.mdx` with quoted date frontmatter.
+3. Replace legacy JSX-only patterns with Markdown or an existing allow-listed component.
+4. Add a static `app/routes/blog.<slug>.tsx` wrapper using the shared article layout.
+5. Add a `.server.ts` assembly module for frontmatter, related posts, series data, and transitional drift checks.
+6. Replace the article's index and series metadata with validated frontmatter.
+7. Extend JavaScript-disabled and workerd coverage to the new representative behavior when it adds a new content pattern.
+8. Confirm `test:mdx:build` keeps the body out of unrelated route closures.
+9. Remove the legacy TSX body only after all catalog, series, related-link, sitemap, and route consumers use the new metadata source.
+
+## Remaining migration work
+
+The first vertical slice intentionally retains the legacy TSX copy as a temporary drift detector. Follow-up slices must:
+
+- migrate the remaining article bodies;
+- generate the complete metadata catalog and route wrappers;
+- remove duplicate TSX bodies and legacy content-component lookups;
+- derive sitemap and related/series validation from the generated catalog;
+- add stricter MDX source or AST policy enforcement before arbitrary contributors author content.

--- a/e2e/mdx.spec.ts
+++ b/e2e/mdx.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test"
+
+const articlePath = "/blog/ai-pipelines-need-control-boundaries"
+
+test("MDX article renders complete content without JavaScript", async ({
+  browser,
+}) => {
+  const context = await browser.newContext({ javaScriptEnabled: false })
+  const page = await context.newPage()
+
+  try {
+    const response = await page.goto(articlePath)
+
+    expect(response?.status()).toBe(200)
+    await expect(
+      page.getByRole("heading", {
+        name: "AI Pipelines Need Control Boundaries",
+      }),
+    ).toBeVisible()
+    await expect(
+      page.getByRole("heading", { name: "Start with the right mental model" }),
+    ).toBeVisible()
+    await expect(
+      page.getByText(
+        "AI is not the system of record. AI is an untrusted reasoning component operating inside a governed integration path.",
+      ),
+    ).toBeVisible()
+    await expect(
+      page.getByRole("img", {
+        name: "Diagram showing sources flowing through preprocessing, MCP boundary, AI layer, post-processing, and finally to controlled targets.",
+      }),
+    ).toHaveAttribute("src", "/img/blog/ai_pipeline_diagram.svg")
+    await expect(
+      page.getByRole("link", {
+        name: "Software Layers Are Risk Boundaries",
+        exact: true,
+      }),
+    ).toHaveAttribute("href", "/blog/software-layers-are-risk-boundaries")
+  } finally {
+    await context.close()
+  }
+})

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:mobile": "playwright test --project=mobile-chromium",
+    "test:mdx:build": "node scripts/test-mdx-build-contract.js",
     "typecheck": "tsc -b",
-    "deploy:cloudflare": "yarn typecheck && yarn build && yarn cloudflare:functions:build && yarn test:cloudflare:bundle-budget && yarn test:cloudflare:adapter && yarn test:cloudflare:runtime && wrangler pages deploy public --project-name ${CLOUDFLARE_PAGES_PROJECT:-micrantha-web} --branch ${CLOUDFLARE_PAGES_BRANCH:-main} --upload-source-maps"
+    "deploy:cloudflare": "yarn typecheck && yarn build && yarn test:mdx:build && yarn cloudflare:functions:build && yarn test:cloudflare:bundle-budget && yarn test:cloudflare:adapter && yarn test:cloudflare:runtime && wrangler pages deploy public --project-name ${CLOUDFLARE_PAGES_PROJECT:-micrantha-web} --branch ${CLOUDFLARE_PAGES_BRANCH:-main} --upload-source-maps"
   },
   "dependencies": {
     "@remix-run/node": "2.17.4",

--- a/remix.env.d.ts
+++ b/remix.env.d.ts
@@ -1,6 +1,19 @@
 /// <reference types="@remix-run/dev" />
 /// <reference types="@remix-run/node/globals" />
 
+import type { ComponentType } from "react"
+
 declare module "react-dom/server.browser" {
   export * from "react-dom/server"
+}
+
+declare module "*.mdx" {
+  export const attributes: unknown
+  export const filename: string
+
+  const Content: ComponentType<{
+    components?: Record<string, ComponentType<Record<string, unknown>>>
+  }>
+
+  export default Content
 }

--- a/remix.env.d.ts
+++ b/remix.env.d.ts
@@ -1,8 +1,6 @@
 /// <reference types="@remix-run/dev" />
 /// <reference types="@remix-run/node/globals" />
 
-import type { ComponentType } from "react"
-
 declare module "react-dom/server.browser" {
   export * from "react-dom/server"
 }
@@ -11,8 +9,8 @@ declare module "*.mdx" {
   export const attributes: unknown
   export const filename: string
 
-  const Content: ComponentType<{
-    components?: Record<string, ComponentType<Record<string, unknown>>>
+  const Content: import("react").ComponentType<{
+    components?: Record<string, import("react").ElementType>
   }>
 
   export default Content

--- a/scripts/test-mdx-build-contract.js
+++ b/scripts/test-mdx-build-contract.js
@@ -64,24 +64,19 @@ function normalizeBuildFile(specifier, fromFile = "") {
   return null
 }
 
-function extractRelativeImports(source, fromFile) {
+function extractStaticRelativeImports(source, fromFile) {
   const specifiers = new Set()
-  const patterns = [
-    /\bimport\s*(?:[^"']*?\sfrom\s*)?["']([^"']+)["']/g,
-    /\bimport\(\s*["']([^"']+)["']\s*\)/g,
-  ]
+  const pattern = /\bimport\s*(?:[^"']*?\sfrom\s*)?["']([^"']+)["']/g
 
-  for (const pattern of patterns) {
-    for (const match of source.matchAll(pattern)) {
-      const normalized = normalizeBuildFile(match[1], fromFile)
-      if (normalized) specifiers.add(normalized)
-    }
+  for (const match of source.matchAll(pattern)) {
+    const normalized = normalizeBuildFile(match[1], fromFile)
+    if (normalized) specifiers.add(normalized)
   }
 
   return [...specifiers]
 }
 
-async function collectRouteClosure(route) {
+async function collectEagerRouteClosure(route) {
   const pending = [
     normalizeBuildFile(route.module),
     ...(route.imports ?? []).map((specifier) => normalizeBuildFile(specifier)),
@@ -99,7 +94,7 @@ async function collectRouteClosure(route) {
     const source = await readFile(path.join(buildRoot, file), "utf8")
     sources.set(file, source)
 
-    for (const importedFile of extractRelativeImports(source, file)) {
+    for (const importedFile of extractStaticRelativeImports(source, file)) {
       if (!visited.has(importedFile)) pending.push(importedFile)
     }
   }
@@ -107,8 +102,10 @@ async function collectRouteClosure(route) {
   return sources
 }
 
-function closureContainsMarker(sources, marker) {
-  return [...sources.values()].some((source) => source.includes(marker))
+function filesContainingMarker(sources, marker) {
+  return [...sources.entries()]
+    .filter(([, source]) => source.includes(marker))
+    .map(([file]) => file)
 }
 
 const articleRoute = requireRoute(routeIds.article)
@@ -121,22 +118,25 @@ assert.notEqual(
 )
 
 const [articleClosure, indexClosure] = await Promise.all([
-  collectRouteClosure(articleRoute),
-  collectRouteClosure(indexRoute),
+  collectEagerRouteClosure(articleRoute),
+  collectEagerRouteClosure(indexRoute),
 ])
 
 for (const marker of articleMarkers) {
+  const articleMatches = filesContainingMarker(articleClosure, marker)
+  const indexMatches = filesContainingMarker(indexClosure, marker)
+
   assert.ok(
-    closureContainsMarker(articleClosure, marker),
+    articleMatches.length > 0,
     `the MDX article route closure is missing marker: ${marker}`,
   )
-  assert.equal(
-    closureContainsMarker(indexClosure, marker),
-    false,
-    `the blog index route closure leaked MDX body marker: ${marker}`,
+  assert.deepEqual(
+    indexMatches,
+    [],
+    `the blog index eager route closure leaked MDX body marker ${marker} through ${indexMatches.join(", ")}`,
   )
 }
 
 console.log(
-  `MDX build contract passed: ${articleClosure.size} article files, ${indexClosure.size} index files`,
+  `MDX build contract passed: ${articleClosure.size} eager article files, ${indexClosure.size} eager index files`,
 )

--- a/scripts/test-mdx-build-contract.js
+++ b/scripts/test-mdx-build-contract.js
@@ -17,6 +17,9 @@ const articleMarkers = [
   "Start with the right mental model",
   "AI is not the system of record",
 ]
+const unrelatedArticleMarkers = [
+  "The integration layer is where identity gets translated",
+]
 
 const buildFiles = await readdir(buildRoot)
 const manifestFiles = buildFiles.filter(
@@ -108,6 +111,16 @@ function filesContainingMarker(sources, marker) {
     .map(([file]) => file)
 }
 
+function assertMarkerAbsent(sources, marker, label) {
+  const matches = filesContainingMarker(sources, marker)
+
+  assert.deepEqual(
+    matches,
+    [],
+    `${label} leaked marker ${marker} through ${matches.join(", ")}`,
+  )
+}
+
 const articleRoute = requireRoute(routeIds.article)
 const indexRoute = requireRoute(routeIds.index)
 
@@ -124,16 +137,28 @@ const [articleClosure, indexClosure] = await Promise.all([
 
 for (const marker of articleMarkers) {
   const articleMatches = filesContainingMarker(articleClosure, marker)
-  const indexMatches = filesContainingMarker(indexClosure, marker)
 
   assert.ok(
     articleMatches.length > 0,
     `the MDX article route closure is missing marker: ${marker}`,
   )
-  assert.deepEqual(
-    indexMatches,
-    [],
-    `the blog index eager route closure leaked MDX body marker ${marker} through ${indexMatches.join(", ")}`,
+  assertMarkerAbsent(
+    indexClosure,
+    marker,
+    "the blog index eager route closure",
+  )
+}
+
+for (const marker of unrelatedArticleMarkers) {
+  assertMarkerAbsent(
+    articleClosure,
+    marker,
+    "the MDX article eager route closure",
+  )
+  assertMarkerAbsent(
+    indexClosure,
+    marker,
+    "the blog index eager route closure",
   )
 }
 

--- a/scripts/test-mdx-build-contract.js
+++ b/scripts/test-mdx-build-contract.js
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict"
+import { readFile, readdir } from "node:fs/promises"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import vm from "node:vm"
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+)
+const buildRoot = path.join(repositoryRoot, "public", "build")
+const routeIds = {
+  article: "routes/blog.ai-pipelines-need-control-boundaries",
+  index: "routes/blog._index",
+}
+const articleMarkers = [
+  "Start with the right mental model",
+  "AI is not the system of record",
+]
+
+const buildFiles = await readdir(buildRoot)
+const manifestFiles = buildFiles.filter(
+  (file) => file.startsWith("manifest-") && file.endsWith(".js"),
+)
+
+assert.equal(
+  manifestFiles.length,
+  1,
+  `expected one Remix browser manifest, found ${manifestFiles.length}`,
+)
+
+const manifestSource = await readFile(
+  path.join(buildRoot, manifestFiles[0]),
+  "utf8",
+)
+const sandbox = { window: {} }
+
+vm.runInNewContext(manifestSource, sandbox, {
+  filename: manifestFiles[0],
+})
+
+const manifest = sandbox.window.__remixManifest
+assert.ok(manifest?.routes, "expected Remix route metadata in browser manifest")
+
+function requireRoute(routeId) {
+  const route = manifest.routes[routeId]
+  assert.ok(route, `missing route ${routeId} from Remix browser manifest`)
+  assert.equal(typeof route.module, "string", `missing module for ${routeId}`)
+  return route
+}
+
+function normalizeBuildFile(specifier, fromFile = "") {
+  if (specifier.startsWith("/build/")) {
+    return specifier.slice("/build/".length)
+  }
+
+  if (specifier.startsWith("./") || specifier.startsWith("../")) {
+    return path
+      .normalize(path.join(path.dirname(fromFile), specifier))
+      .split(path.sep)
+      .join("/")
+  }
+
+  return null
+}
+
+function extractRelativeImports(source, fromFile) {
+  const specifiers = new Set()
+  const patterns = [
+    /\bimport\s*(?:[^"']*?\sfrom\s*)?["']([^"']+)["']/g,
+    /\bimport\(\s*["']([^"']+)["']\s*\)/g,
+  ]
+
+  for (const pattern of patterns) {
+    for (const match of source.matchAll(pattern)) {
+      const normalized = normalizeBuildFile(match[1], fromFile)
+      if (normalized) specifiers.add(normalized)
+    }
+  }
+
+  return [...specifiers]
+}
+
+async function collectRouteClosure(route) {
+  const pending = [
+    normalizeBuildFile(route.module),
+    ...(route.imports ?? []).map((specifier) => normalizeBuildFile(specifier)),
+  ].filter(Boolean)
+  const visited = new Set()
+  const sources = new Map()
+
+  while (pending.length > 0) {
+    const file = pending.pop()
+
+    if (!file || visited.has(file)) continue
+
+    visited.add(file)
+
+    const source = await readFile(path.join(buildRoot, file), "utf8")
+    sources.set(file, source)
+
+    for (const importedFile of extractRelativeImports(source, file)) {
+      if (!visited.has(importedFile)) pending.push(importedFile)
+    }
+  }
+
+  return sources
+}
+
+function closureContainsMarker(sources, marker) {
+  return [...sources.values()].some((source) => source.includes(marker))
+}
+
+const articleRoute = requireRoute(routeIds.article)
+const indexRoute = requireRoute(routeIds.index)
+
+assert.notEqual(
+  articleRoute.module,
+  indexRoute.module,
+  "the static MDX article must have its own browser route module",
+)
+
+const [articleClosure, indexClosure] = await Promise.all([
+  collectRouteClosure(articleRoute),
+  collectRouteClosure(indexRoute),
+])
+
+for (const marker of articleMarkers) {
+  assert.ok(
+    closureContainsMarker(articleClosure, marker),
+    `the MDX article route closure is missing marker: ${marker}`,
+  )
+  assert.equal(
+    closureContainsMarker(indexClosure, marker),
+    false,
+    `the blog index route closure leaked MDX body marker: ${marker}`,
+  )
+}
+
+console.log(
+  `MDX build contract passed: ${articleClosure.size} article files, ${indexClosure.size} index files`,
+)


### PR DESCRIPTION
## Summary

- move the published `AI Pipelines Need Control Boundaries` body into declarative MDX without changing its copy, metadata, diagram, related links, or series position
- add a static Remix route wrapper that owns loaders, SEO, structured data, layout, and the allow-listed component map
- validate MDX frontmatter and use it as the migrated post's authoritative metadata on the article, blog index, related links, and series page
- keep transitional TSX catalog and series resolution behind `.server.ts` assembly modules
- keep legacy TSX posts behind the existing dynamic route while sharing one serializable article layout
- add JavaScript-disabled Playwright coverage
- add an emitted Remix-manifest contract that rejects article-body leakage into the blog index or unrelated route chunks
- reuse the source-isolated Cloudflare/workerd article contract to prove the compiled MDX route runs without source files or compiler packages
- document the repeatable authoring and migration workflow

## Architecture

The canonical article source is:

```text
app/content/posts/ai-pipelines-need-control-boundaries.mdx
```

The static wrapper is:

```text
app/routes/blog.ai-pipelines-need-control-boundaries.tsx
```

Server-only assembly modules own frontmatter import, transitional catalog checks, index cards, related posts, and series resolution. Browser route modules receive serializable loader data only.

The MDX file contains frontmatter, Markdown, native semantic elements, and only these allow-listed components:

- `Callout`
- `Figure`
- `PostLink`

It contains no imports, Remix exports, loaders, environment access, or article-specific React components.

## Frontmatter contract

Validated fields include:

- route-matching slug
- title and description
- quoted date in `YYYY-MM-DD`
- excerpt
- unique tags
- unique related slugs with no self-reference
- series slug, title, and positive order

The server compatibility layer fails when migrated metadata or series placement differs from the transitional legacy catalog.

## Browser bundle contract

`yarn test:mdx:build` evaluates the emitted Classic Remix browser manifest and follows eager static imports only. It verifies:

- the migrated body is present in its dedicated static route closure
- the migrated body is absent from the blog index closure
- a known unrelated legacy article body is absent from both the MDX article and blog index closures
- the static article and blog index have distinct route modules

The command runs in required CI and before Cloudflare deployment.

## Rendering and validation

Required CI must prove:

- full-repository formatting, lint, and typechecking
- Classic Remix production compilation of imported MDX
- complete SSR with JavaScript disabled
- metadata, related links, series navigation, table, callout, and diagram output
- emitted browser chunk isolation
- pinned Wrangler Pages Function compilation and bundle budgets
- direct adapter contract
- source-isolated asset-first workerd rendering of the migrated route
- existing desktop/mobile Playwright coverage

The workflow is documented in `docs/content/blog-mdx.md`.

## Scope

This is the first representative vertical slice for #55, not the full migration. Remaining posts, generated catalog and route wrappers, removal of the transitional TSX copy, sitemap generation, duplicate-body cleanup, and stricter MDX source/AST policy enforcement remain follow-up work after this architecture is proven.