### PR TITLE
Add the representative build-time MDX article route

### DIFF
--- a/app/components/blog-article-layout.tsx
+++ b/app/components/blog-article-layout.tsx
@@ -1,0 +1,137 @@
+import type { ReactNode } from "react"
+import { Link } from "@remix-run/react"
+
+import { formatBlogDate, type BlogPost } from "~/content/blog"
+import { getRelatedPosts } from "~/content/blog-provider"
+import { getSeriesNavigation } from "~/content/blog-series"
+
+import { PageTitle } from "./page-title"
+
+export function BlogArticleLayout({
+  post,
+  children,
+}: {
+  post: BlogPost
+  children: ReactNode
+}) {
+  const relatedPosts = getRelatedPosts(post)
+  const seriesNavigation = getSeriesNavigation(post)
+
+  return (
+    <article className="space-y-10">
+      <div className="space-y-5">
+        <Link className="article-meta-link inline-flex text-sm" to="/blog">
+          Back to blog
+        </Link>
+        <PageTitle title={post.title} subtitle={post.description} />
+        <div className="article-meta-row flex flex-wrap items-center gap-x-4 gap-y-2">
+          <time dateTime={post.date}>{formatBlogDate(post.date)}</time>
+          <span aria-hidden="true">/</span>
+          <span>{post.tags.join(", ")}</span>
+        </div>
+        <p className="article-lead">{post.excerpt}</p>
+      </div>
+
+      {seriesNavigation ? (
+        <section className="max-w-3xl rounded-2xl border border-slate-200 bg-slate-50/80 px-5 py-5 shadow-[0_10px_24px_rgba(31,42,42,0.05)]">
+          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div className="space-y-2">
+              <p className="meta-kicker">Series</p>
+              <h2 className="text-[1.25rem] font-semibold tracking-[-0.02em] text-slate-900">
+                <Link to={`/blog/series/${seriesNavigation.series.slug}`}>
+                  {seriesNavigation.series.title}
+                </Link>
+              </h2>
+              <p className="page-copy-sm">
+                Part {seriesNavigation.index + 1} of {seriesNavigation.total}
+              </p>
+            </div>
+            <nav
+              className="grid gap-2 text-sm md:min-w-[16rem]"
+              aria-label={`${seriesNavigation.series.title} series navigation`}
+            >
+              {seriesNavigation.previous ? (
+                <Link
+                  className="article-meta-link"
+                  to={`/blog/${seriesNavigation.previous.slug}`}
+                >
+                  Previous: {seriesNavigation.previous.title}
+                </Link>
+              ) : null}
+              {seriesNavigation.next ? (
+                <Link
+                  className="article-meta-link"
+                  to={`/blog/${seriesNavigation.next.slug}`}
+                >
+                  Next: {seriesNavigation.next.title}
+                </Link>
+              ) : null}
+            </nav>
+          </div>
+        </section>
+      ) : null}
+
+      <div className="article-prose">{children}</div>
+
+      {seriesNavigation ? (
+        <section className="max-w-3xl space-y-4 border-t border-gray-200 pt-8">
+          <h2 className="text-[1.35rem] font-semibold tracking-[-0.02em] text-slate-900">
+            In this series
+          </h2>
+          <div className="grid gap-3">
+            {seriesNavigation.posts.map((seriesPost, index) => {
+              const isCurrent = seriesPost.slug === post.slug
+
+              return (
+                <Link
+                  key={seriesPost.slug}
+                  to={`/blog/${seriesPost.slug}`}
+                  aria-current={isCurrent ? "page" : undefined}
+                  className={
+                    isCurrent
+                      ? "rounded-2xl border border-slate-300 bg-white px-4 py-4 text-left text-base shadow-[0_10px_24px_rgba(31,42,42,0.08)]"
+                      : "rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-4 text-left text-base shadow-[0_10px_24px_rgba(31,42,42,0.05)] transition-colors hover:bg-white"
+                  }
+                >
+                  <span className="meta-kicker mb-1 block">
+                    Part {index + 1}
+                  </span>
+                  <span className="block text-[1.02rem] font-semibold leading-7 tracking-[-0.015em] text-slate-900">
+                    {seriesPost.title}
+                  </span>
+                  <span className="mt-2 block text-sm leading-7 text-slate-600">
+                    {seriesPost.excerpt}
+                  </span>
+                </Link>
+              )
+            })}
+          </div>
+        </section>
+      ) : null}
+
+      {relatedPosts.length > 0 ? (
+        <section className="max-w-3xl space-y-4 border-t border-gray-200 pt-8">
+          <h2 className="text-[1.35rem] font-semibold tracking-[-0.02em] text-slate-900">
+            Related notes
+          </h2>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            {relatedPosts.map((relatedPost) => (
+              <Link
+                key={relatedPost.slug}
+                to={`/blog/${relatedPost.slug}`}
+                className="rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-4 text-left text-base shadow-[0_10px_24px_rgba(31,42,42,0.05)] transition-colors hover:bg-white"
+              >
+                <span className="block text-[1.02rem] font-semibold leading-7 tracking-[-0.015em] text-slate-900">
+                  {relatedPost.title}
+                </span>
+                <span className="mt-2 block text-sm leading-7 text-slate-600">
+                  {relatedPost.excerpt}
+                </span>
+              </Link>
+            ))}
+          </div>
+        </section>
+      ) : null}
+    </article>
+  )
+}

--- a/app/components/blog-mdx-components.tsx
+++ b/app/components/blog-mdx-components.tsx
@@ -37,6 +37,40 @@ export function Figure({
   )
 }
 
+type ControlTableRow = {
+  cause: string
+  failureMode: string
+  response: string
+}
+
+export function ControlTable({ rows }: { rows: ControlTableRow[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table
+        aria-label="AI pipeline failure modes"
+        className="min-w-[48rem] border-collapse text-left"
+      >
+        <thead>
+          <tr>
+            <th scope="col">Failure mode</th>
+            <th scope="col">What usually causes it</th>
+            <th scope="col">Control response</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.failureMode}>
+              <th scope="row">{row.failureMode}</th>
+              <td>{row.cause}</td>
+              <td>{row.response}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
 export function PostLink({
   children,
   slug,
@@ -49,6 +83,7 @@ export function PostLink({
 
 export const blogMdxComponents = {
   Callout,
+  ControlTable,
   Figure,
   PostLink,
 }

--- a/app/components/blog-mdx-components.tsx
+++ b/app/components/blog-mdx-components.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from "react"
+import { Link } from "@remix-run/react"
+
+export function Callout({ children }: { children: ReactNode }) {
+  return <div className="article-callout">{children}</div>
+}
+
+export function Figure({
+  alt,
+  caption,
+  narrow = false,
+  src,
+  title,
+}: {
+  alt: string
+  caption: string
+  narrow?: boolean
+  src: string
+  title: string
+}) {
+  return (
+    <figure className="article-diagram">
+      <figcaption className="article-diagram-caption">
+        <span className="article-diagram-title">{title}</span>
+        <span className="article-diagram-note">{caption}</span>
+      </figcaption>
+      <img
+        className={
+          narrow
+            ? "article-diagram-image article-diagram-image-narrow"
+            : "article-diagram-image"
+        }
+        src={src}
+        alt={alt}
+      />
+    </figure>
+  )
+}
+
+export function PostLink({
+  children,
+  slug,
+}: {
+  children: ReactNode
+  slug: string
+}) {
+  return <Link to={`/blog/${slug}`}>{children}</Link>
+}
+
+export const blogMdxComponents = {
+  Callout,
+  Figure,
+  PostLink,
+}

--- a/app/mdx.d.ts
+++ b/app/mdx.d.ts
@@ -1,0 +1,11 @@
+declare module "*.mdx" {
+  import type { ComponentType, ElementType } from "react"
+
+  export const attributes: Record<string, unknown>
+
+  const MdxComponent: ComponentType<{
+    components?: Record<string, ElementType>
+  }>
+
+  export default MdxComponent
+}

--- a/app/routes/blog.$slug.tsx
+++ b/app/routes/blog.$slug.tsx
@@ -1,10 +1,9 @@
 import type { LoaderFunctionArgs, MetaFunction } from "@remix-run/node"
 import { json } from "@remix-run/node"
-import { Link, useLoaderData } from "@remix-run/react"
-import { PageTitle } from "~/components"
-import { formatBlogDate } from "~/content/blog"
-import { getBlogPostBySlug, getRelatedPosts } from "~/content/blog-provider"
-import { getSeriesNavigation } from "~/content/blog-series"
+import { useLoaderData } from "@remix-run/react"
+
+import { BlogArticleLayout } from "~/components/blog-article-layout"
+import { getBlogPostBySlug } from "~/content/blog-provider"
 import { buildArticleMeta, buildArticleStructuredData } from "~/utils/seo"
 
 type LoaderData = {
@@ -76,126 +75,9 @@ export default function BlogPostRoute() {
     throw new Error(`Missing blog post for slug: ${postMeta.slug}`)
   }
 
-  const relatedPosts = getRelatedPosts(post)
-  const seriesNavigation = getSeriesNavigation(post)
-
   return (
-    <article className="space-y-10">
-      <div className="space-y-5">
-        <Link className="article-meta-link inline-flex text-sm" to="/blog">
-          Back to blog
-        </Link>
-        <PageTitle title={post.title} subtitle={post.description} />
-        <div className="article-meta-row flex flex-wrap items-center gap-x-4 gap-y-2">
-          <time dateTime={post.date}>{formatBlogDate(post.date)}</time>
-          <span aria-hidden="true">/</span>
-          <span>{post.tags.join(", ")}</span>
-        </div>
-        <p className="article-lead">{post.excerpt}</p>
-      </div>
-
-      {seriesNavigation ? (
-        <section className="max-w-3xl rounded-2xl border border-slate-200 bg-slate-50/80 px-5 py-5 shadow-[0_10px_24px_rgba(31,42,42,0.05)]">
-          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-            <div className="space-y-2">
-              <p className="meta-kicker">Series</p>
-              <h2 className="text-[1.25rem] font-semibold tracking-[-0.02em] text-slate-900">
-                <Link to={`/blog/series/${seriesNavigation.series.slug}`}>
-                  {seriesNavigation.series.title}
-                </Link>
-              </h2>
-              <p className="page-copy-sm">
-                Part {seriesNavigation.index + 1} of {seriesNavigation.total}
-              </p>
-            </div>
-            <nav
-              className="grid gap-2 text-sm md:min-w-[16rem]"
-              aria-label={`${seriesNavigation.series.title} series navigation`}
-            >
-              {seriesNavigation.previous ? (
-                <Link
-                  className="article-meta-link"
-                  to={`/blog/${seriesNavigation.previous.slug}`}
-                >
-                  Previous: {seriesNavigation.previous.title}
-                </Link>
-              ) : null}
-              {seriesNavigation.next ? (
-                <Link
-                  className="article-meta-link"
-                  to={`/blog/${seriesNavigation.next.slug}`}
-                >
-                  Next: {seriesNavigation.next.title}
-                </Link>
-              ) : null}
-            </nav>
-          </div>
-        </section>
-      ) : null}
-
-      <div className="article-prose">
-        <post.Content />
-      </div>
-
-      {seriesNavigation ? (
-        <section className="max-w-3xl space-y-4 border-t border-gray-200 pt-8">
-          <h2 className="text-[1.35rem] font-semibold tracking-[-0.02em] text-slate-900">
-            In this series
-          </h2>
-          <div className="grid gap-3">
-            {seriesNavigation.posts.map((seriesPost, index) => {
-              const isCurrent = seriesPost.slug === post.slug
-
-              return (
-                <Link
-                  key={seriesPost.slug}
-                  to={`/blog/${seriesPost.slug}`}
-                  aria-current={isCurrent ? "page" : undefined}
-                  className={
-                    isCurrent
-                      ? "rounded-2xl border border-slate-300 bg-white px-4 py-4 text-left text-base shadow-[0_10px_24px_rgba(31,42,42,0.08)]"
-                      : "rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-4 text-left text-base shadow-[0_10px_24px_rgba(31,42,42,0.05)] transition-colors hover:bg-white"
-                  }
-                >
-                  <span className="meta-kicker mb-1 block">
-                    Part {index + 1}
-                  </span>
-                  <span className="block text-[1.02rem] font-semibold leading-7 tracking-[-0.015em] text-slate-900">
-                    {seriesPost.title}
-                  </span>
-                  <span className="mt-2 block text-sm leading-7 text-slate-600">
-                    {seriesPost.excerpt}
-                  </span>
-                </Link>
-              )
-            })}
-          </div>
-        </section>
-      ) : null}
-
-      {relatedPosts.length > 0 ? (
-        <section className="max-w-3xl space-y-4 border-t border-gray-200 pt-8">
-          <h2 className="text-[1.35rem] font-semibold tracking-[-0.02em] text-slate-900">
-            Related notes
-          </h2>
-          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-            {relatedPosts.map((relatedPost) => (
-              <Link
-                key={relatedPost.slug}
-                to={`/blog/${relatedPost.slug}`}
-                className="rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-4 text-left text-base shadow-[0_10px_24px_rgba(31,42,42,0.05)] transition-colors hover:bg-white"
-              >
-                <span className="block text-[1.02rem] font-semibold leading-7 tracking-[-0.015em] text-slate-900">
-                  {relatedPost.title}
-                </span>
-                <span className="mt-2 block text-sm leading-7 text-slate-600">
-                  {relatedPost.excerpt}
-                </span>
-              </Link>
-            ))}
-          </div>
-        </section>
-      ) : null}
-    </article>
+    <BlogArticleLayout post={post}>
+      <post.Content />
+    </BlogArticleLayout>
   )
 }

--- a/app/routes/blog.ai-pipelines-need-control-boundaries/content.mdx
+++ b/app/routes/blog.ai-pipelines-need-control-boundaries/content.mdx
@@ -1,0 +1,86 @@
+---
+slug: ai-pipelines-need-control-boundaries
+title: AI Pipelines Need Control Boundaries
+description: Enterprise AI should be treated as an untrusted reasoning component inside a governed integration path.
+date: "2026-04-24"
+excerpt: Enterprise AI becomes safer and more useful when normalization, authorization, validation, and write-back controls are explicit around it.
+tags:
+  - architecture-notes
+  - ai-governance
+  - workflow-validation
+  - secure-integration
+relatedSlugs:
+  - secure-platform-integration-is-not-plumbing
+  - software-layers-are-risk-boundaries
+---
+
+## Start with the right mental model
+
+Enterprise AI work becomes risky when the model is treated like an authoritative component instead of a fallible part of a larger delivery path.
+
+<Callout>
+
+AI is not the system of record. AI is an untrusted reasoning component operating inside a governed integration path.
+
+</Callout>
+
+That framing changes the design. Prompts, tool access, retrieval, outputs, and write-back actions all need control boundaries of their own.
+
+## Pre-processing
+
+Input control starts before a model sees anything. Raw enterprise data usually needs normalization to reduce ambiguity, redaction to remove material the model does not need, enrichment to provide stable business context, and provenance markers so downstream reviewers can see what sources shaped the result.
+
+- Normalize structure and terminology so prompts do not depend on unstable source formatting.
+- Redact sensitive fields when they are not necessary for the reasoning task.
+- Enrich with identifiers, policy context, and known workflow state.
+- Attach provenance so outputs can be inspected against real evidence.
+
+## MCP and tool boundary
+
+Tool access should be scoped like any other privileged interface. Exposing a broad tool surface because a model might find it useful is the wrong default. The model should receive only the tools, methods, and data slices required for the current workflow step.
+
+- Scope access to the task and actor, not the whole platform.
+- Require authorization at the tool boundary, not only in prompts.
+- Audit tool invocations and carry the calling workflow identity.
+- Treat MCP or similar tool channels as integration surfaces subject to the same control design as any other API.
+
+## AI execution
+
+<Figure
+  title="Governed AI pipeline"
+  caption="AI lives inside a controlled path with explicit checks before and after reasoning."
+  src="/img/blog/ai_pipeline_diagram.svg"
+  alt="Diagram showing sources flowing through preprocessing, MCP boundary, AI layer, post-processing, and finally to controlled targets."
+  narrow
+/>
+
+Inside the execution zone, retrieval, model or agent selection, and tool calls are still just intermediate reasoning steps. They are useful, but they should not be confused with final system action. There needs to be a visible boundary between the reasoning process and the transaction that changes a real workflow.
+
+This is where a layered architecture matters. The same separation described in <PostLink slug="software-layers-are-risk-boundaries">Software Layers Are Risk Boundaries</PostLink> keeps AI-specific logic from leaking directly into systems of record.
+
+## Post-processing and approval
+
+Before anything is written back, the result needs to be validated, scored, compared with expected structures, and, where necessary, held for approval. This is the difference between an assistant and an uncontrolled actor.
+
+- Validate schema, policy requirements, and required fields.
+- Score confidence or rule conformance using deterministic checks rather than model self-assessment alone.
+- Diff proposed changes against current records so reviewers can see the exact effect.
+- Require explicit approval when the action changes regulated workflow, status, or customer-visible records.
+
+## Controlled write-back
+
+The write-back step should look like a normal governed integration: authorized actor, validated payload, logged decision, and a durable trace of what was changed. If that control surface does not exist, the pipeline is not ready for enterprise use.
+
+## Threat and failure modes
+
+| Failure mode | What usually causes it | Control response |
+| --- | --- | --- |
+| Over-broad tool access | Convenience-driven integration and prompt-only policy | Scope tools by workflow, enforce authorization, audit calls |
+| Unverifiable output | Missing provenance and no deterministic validation | Attach sources, run schema checks, retain review traces |
+| Unsafe write-back | Model output sent directly to systems of record | Require approval gates and controlled adapter writes |
+| Prompt leakage of sensitive data | Skipping normalization and redaction upstream | Pre-process inputs and minimize exposed fields |
+| Workflow drift | AI-specific logic embedded in every consumer | Keep orchestration in an application boundary |
+
+## Conclusion
+
+The practical goal is not to remove AI from the workflow. It is to put AI in a governed part of the workflow without letting it become the implicit owner of security, state, or business truth. Once the control boundaries are explicit, enterprise AI becomes easier to test, review, and replace.

--- a/app/routes/blog.ai-pipelines-need-control-boundaries/content.mdx
+++ b/app/routes/blog.ai-pipelines-need-control-boundaries/content.mdx
@@ -73,13 +73,35 @@ The write-back step should look like a normal governed integration: authorized a
 
 ## Threat and failure modes
 
-| Failure mode                     | What usually causes it                                | Control response                                            |
-| -------------------------------- | ----------------------------------------------------- | ----------------------------------------------------------- |
-| Over-broad tool access           | Convenience-driven integration and prompt-only policy | Scope tools by workflow, enforce authorization, audit calls |
-| Unverifiable output              | Missing provenance and no deterministic validation    | Attach sources, run schema checks, retain review traces     |
-| Unsafe write-back                | Model output sent directly to systems of record       | Require approval gates and controlled adapter writes        |
-| Prompt leakage of sensitive data | Skipping normalization and redaction upstream         | Pre-process inputs and minimize exposed fields              |
-| Workflow drift                   | AI-specific logic embedded in every consumer          | Keep orchestration in an application boundary               |
+<ControlTable
+  rows={[
+    {
+      failureMode: "Over-broad tool access",
+      cause: "Convenience-driven integration and prompt-only policy",
+      response: "Scope tools by workflow, enforce authorization, audit calls",
+    },
+    {
+      failureMode: "Unverifiable output",
+      cause: "Missing provenance and no deterministic validation",
+      response: "Attach sources, run schema checks, retain review traces",
+    },
+    {
+      failureMode: "Unsafe write-back",
+      cause: "Model output sent directly to systems of record",
+      response: "Require approval gates and controlled adapter writes",
+    },
+    {
+      failureMode: "Prompt leakage of sensitive data",
+      cause: "Skipping normalization and redaction upstream",
+      response: "Pre-process inputs and minimize exposed fields",
+    },
+    {
+      failureMode: "Workflow drift",
+      cause: "AI-specific logic embedded in every consumer",
+      response: "Keep orchestration in an application boundary",
+    },
+  ]}
+/>
 
 ## Conclusion
 

--- a/app/routes/blog.ai-pipelines-need-control-boundaries/content.mdx
+++ b/app/routes/blog.ai-pipelines-need-control-boundaries/content.mdx
@@ -73,13 +73,13 @@ The write-back step should look like a normal governed integration: authorized a
 
 ## Threat and failure modes
 
-| Failure mode | What usually causes it | Control response |
-| --- | --- | --- |
-| Over-broad tool access | Convenience-driven integration and prompt-only policy | Scope tools by workflow, enforce authorization, audit calls |
-| Unverifiable output | Missing provenance and no deterministic validation | Attach sources, run schema checks, retain review traces |
-| Unsafe write-back | Model output sent directly to systems of record | Require approval gates and controlled adapter writes |
-| Prompt leakage of sensitive data | Skipping normalization and redaction upstream | Pre-process inputs and minimize exposed fields |
-| Workflow drift | AI-specific logic embedded in every consumer | Keep orchestration in an application boundary |
+| Failure mode                     | What usually causes it                                | Control response                                            |
+| -------------------------------- | ----------------------------------------------------- | ----------------------------------------------------------- |
+| Over-broad tool access           | Convenience-driven integration and prompt-only policy | Scope tools by workflow, enforce authorization, audit calls |
+| Unverifiable output              | Missing provenance and no deterministic validation    | Attach sources, run schema checks, retain review traces     |
+| Unsafe write-back                | Model output sent directly to systems of record       | Require approval gates and controlled adapter writes        |
+| Prompt leakage of sensitive data | Skipping normalization and redaction upstream         | Pre-process inputs and minimize exposed fields              |
+| Workflow drift                   | AI-specific logic embedded in every consumer          | Keep orchestration in an application boundary               |
 
 ## Conclusion
 

--- a/app/routes/blog.ai-pipelines-need-control-boundaries/route.tsx
+++ b/app/routes/blog.ai-pipelines-need-control-boundaries/route.tsx
@@ -1,0 +1,108 @@
+import type { MetaFunction } from "@remix-run/node"
+
+import { BlogArticleLayout } from "~/components/blog-article-layout"
+import { blogMdxComponents } from "~/components/blog-mdx-components"
+import type { BlogPost } from "~/content/blog"
+import { getBlogPostBySlug } from "~/content/blog-provider"
+import { buildArticleMeta, buildArticleStructuredData } from "~/utils/seo"
+
+import Content, { attributes } from "./content.mdx"
+
+const EXPECTED_SLUG = "ai-pipelines-need-control-boundaries"
+
+function requiredString(name: string) {
+  const value = attributes[name]
+
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`Invalid MDX frontmatter field: ${name}`)
+  }
+
+  return value
+}
+
+function requiredStringArray(name: string) {
+  const value = attributes[name]
+
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    value.some((item) => typeof item !== "string" || item.trim() === "")
+  ) {
+    throw new Error(`Invalid MDX frontmatter field: ${name}`)
+  }
+
+  const normalized = value.map((item) => item.trim())
+
+  if (new Set(normalized).size !== normalized.length) {
+    throw new Error(`Duplicate values in MDX frontmatter field: ${name}`)
+  }
+
+  return normalized
+}
+
+const slug = requiredString("slug")
+const date = requiredString("date")
+
+if (slug !== EXPECTED_SLUG) {
+  throw new Error(`MDX slug ${slug} does not match route ${EXPECTED_SLUG}`)
+}
+
+if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || Number.isNaN(Date.parse(date))) {
+  throw new Error(`Invalid MDX publication date: ${date}`)
+}
+
+const post: BlogPost = {
+  slug,
+  title: requiredString("title"),
+  description: requiredString("description"),
+  date,
+  excerpt: requiredString("excerpt"),
+  tags: requiredStringArray("tags"),
+  relatedSlugs: requiredStringArray("relatedSlugs"),
+  Content: () => null,
+}
+
+const registryPost = getBlogPostBySlug(post.slug)
+
+if (!registryPost) {
+  throw new Error(`Missing registry metadata for MDX post: ${post.slug}`)
+}
+
+for (const field of ["title", "description", "date", "excerpt"] as const) {
+  if (registryPost[field] !== post[field]) {
+    throw new Error(`MDX frontmatter differs from registry field: ${field}`)
+  }
+}
+
+for (const field of ["tags", "relatedSlugs"] as const) {
+  if (JSON.stringify(registryPost[field]) !== JSON.stringify(post[field])) {
+    throw new Error(`MDX frontmatter differs from registry field: ${field}`)
+  }
+}
+
+export const meta: MetaFunction = () =>
+  buildArticleMeta({
+    title: post.title,
+    description: post.description,
+    path: `/blog/${post.slug}`,
+    publishedTime: `${post.date}T00:00:00Z`,
+    tags: post.tags,
+  })
+
+export const handle = {
+  structuredData: buildArticleStructuredData({
+    title: post.title,
+    description: post.description,
+    path: `/blog/${post.slug}`,
+    datePublished: `${post.date}T00:00:00Z`,
+    keywords: post.tags,
+  }),
+}
+
+export default function AiPipelinesNeedControlBoundariesRoute() {
+  return (
+    <BlogArticleLayout post={post}>
+      <Content components={blogMdxComponents} />
+    </BlogArticleLayout>
+  )
+}

--- a/app/routes/blog.ai-pipelines-need-control-boundaries/route.tsx
+++ b/app/routes/blog.ai-pipelines-need-control-boundaries/route.tsx
@@ -102,7 +102,9 @@ export const handle = {
 export default function AiPipelinesNeedControlBoundariesRoute() {
   return (
     <BlogArticleLayout post={post}>
-      <Content components={blogMdxComponents} />
+      <div data-content-source="mdx">
+        <Content components={blogMdxComponents} />
+      </div>
     </BlogArticleLayout>
   )
 }

--- a/e2e/mdx.spec.ts
+++ b/e2e/mdx.spec.ts
@@ -46,9 +46,12 @@ test.describe("representative MDX article", () => {
       "href",
       "https://micrantha.com/blog/ai-pipelines-need-control-boundaries",
     )
-    await expect(
-      page.locator('script[type="application/ld+json"]'),
-    ).toContainText('"@type":"Article"')
+
+    const structuredData = await page
+      .locator('script[type="application/ld+json"]')
+      .textContent()
+
+    expect(structuredData).toContain('"@type":"Article"')
   })
 
   test("supports hydrated client navigation", async ({ page }) => {

--- a/e2e/mdx.spec.ts
+++ b/e2e/mdx.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "@playwright/test"
+
+const articlePath = "/blog/ai-pipelines-need-control-boundaries"
+
+test.describe("representative MDX article", () => {
+  test("renders canonical content, components, and metadata", async ({ page }) => {
+    await page.goto(articlePath)
+
+    await expect(page).toHaveTitle(
+      /AI Pipelines Need Control Boundaries.*Micrantha Software/,
+    )
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: "AI Pipelines Need Control Boundaries",
+      }),
+    ).toBeVisible()
+    await expect(page.locator('[data-content-source="mdx"]')).toBeVisible()
+    await expect(page.locator(".article-callout")).toContainText(
+      "AI is not the system of record",
+    )
+    await expect(
+      page.getByRole("img", { name: /sources flowing through preprocessing/i }),
+    ).toBeVisible()
+    await expect(
+      page.getByRole("link", { name: "Software Layers Are Risk Boundaries" }),
+    ).toHaveAttribute("href", "/blog/software-layers-are-risk-boundaries")
+
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+      "href",
+      "https://micrantha.com/blog/ai-pipelines-need-control-boundaries",
+    )
+    await expect(page.locator('script[type="application/ld+json"]')).toContainText(
+      '"@type":"Article"',
+    )
+  })
+
+  test("supports hydrated client navigation", async ({ page }) => {
+    await page.goto(articlePath)
+    await page
+      .getByRole("link", { name: "Software Layers Are Risk Boundaries" })
+      .click()
+
+    await expect(page).toHaveURL(/\/blog\/software-layers-are-risk-boundaries$/)
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: "Software Layers Are Risk Boundaries",
+      }),
+    ).toBeVisible()
+  })
+})
+
+test.describe("representative MDX article without JavaScript", () => {
+  test.use({ javaScriptEnabled: false })
+
+  test("returns complete server-rendered article content", async ({ page }) => {
+    const response = await page.goto(articlePath)
+
+    expect(response?.status()).toBe(200)
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: "AI Pipelines Need Control Boundaries",
+      }),
+    ).toBeVisible()
+    await expect(page.locator('[data-content-source="mdx"]')).toContainText(
+      "The practical goal is not to remove AI from the workflow",
+    )
+    await expect(page.locator(".article-callout")).toContainText(
+      "untrusted reasoning component",
+    )
+  })
+})

--- a/e2e/mdx.spec.ts
+++ b/e2e/mdx.spec.ts
@@ -3,7 +3,9 @@ import { expect, test } from "@playwright/test"
 const articlePath = "/blog/ai-pipelines-need-control-boundaries"
 
 test.describe("representative MDX article", () => {
-  test("renders canonical content, components, and metadata", async ({ page }) => {
+  test("renders canonical content, components, and metadata", async ({
+    page,
+  }) => {
     await page.goto(articlePath)
 
     await expect(page).toHaveTitle(
@@ -30,9 +32,9 @@ test.describe("representative MDX article", () => {
       "href",
       "https://micrantha.com/blog/ai-pipelines-need-control-boundaries",
     )
-    await expect(page.locator('script[type="application/ld+json"]')).toContainText(
-      '"@type":"Article"',
-    )
+    await expect(
+      page.locator('script[type="application/ld+json"]'),
+    ).toContainText('"@type":"Article"')
   })
 
   test("supports hydrated client navigation", async ({ page }) => {

--- a/e2e/mdx.spec.ts
+++ b/e2e/mdx.spec.ts
@@ -9,7 +9,7 @@ test.describe("representative MDX article", () => {
     await page.goto(articlePath)
 
     await expect(page).toHaveTitle(
-      /AI Pipelines Need Control Boundaries.*Micrantha Software/,
+      "Micrantha Software | AI Pipelines Need Control Boundaries",
     )
     await expect(
       page.getByRole("heading", {
@@ -17,15 +17,29 @@ test.describe("representative MDX article", () => {
         name: "AI Pipelines Need Control Boundaries",
       }),
     ).toBeVisible()
-    await expect(page.locator('[data-content-source="mdx"]')).toBeVisible()
-    await expect(page.locator(".article-callout")).toContainText(
+
+    const mdxContent = page.locator('[data-content-source="mdx"]')
+
+    await expect(mdxContent).toBeVisible()
+    await expect(mdxContent.locator(".article-callout")).toContainText(
       "AI is not the system of record",
     )
     await expect(
-      page.getByRole("img", { name: /sources flowing through preprocessing/i }),
+      mdxContent.getByRole("img", {
+        name: /sources flowing through preprocessing/i,
+      }),
     ).toBeVisible()
     await expect(
-      page.getByRole("link", { name: "Software Layers Are Risk Boundaries" }),
+      mdxContent.getByRole("table", { name: "AI pipeline failure modes" }),
+    ).toBeVisible()
+    await expect(
+      mdxContent.getByRole("row", { name: /Unsafe write-back/ }),
+    ).toContainText("Require approval gates and controlled adapter writes")
+    await expect(
+      mdxContent.getByRole("link", {
+        name: "Software Layers Are Risk Boundaries",
+        exact: true,
+      }),
     ).toHaveAttribute("href", "/blog/software-layers-are-risk-boundaries")
 
     await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
@@ -40,7 +54,11 @@ test.describe("representative MDX article", () => {
   test("supports hydrated client navigation", async ({ page }) => {
     await page.goto(articlePath)
     await page
-      .getByRole("link", { name: "Software Layers Are Risk Boundaries" })
+      .locator('[data-content-source="mdx"]')
+      .getByRole("link", {
+        name: "Software Layers Are Risk Boundaries",
+        exact: true,
+      })
       .click()
 
     await expect(page).toHaveURL(/\/blog\/software-layers-are-risk-boundaries$/)
@@ -66,11 +84,17 @@ test.describe("representative MDX article without JavaScript", () => {
         name: "AI Pipelines Need Control Boundaries",
       }),
     ).toBeVisible()
-    await expect(page.locator('[data-content-source="mdx"]')).toContainText(
+
+    const mdxContent = page.locator('[data-content-source="mdx"]')
+
+    await expect(mdxContent).toContainText(
       "The practical goal is not to remove AI from the workflow",
     )
-    await expect(page.locator(".article-callout")).toContainText(
+    await expect(mdxContent.locator(".article-callout")).toContainText(
       "untrusted reasoning component",
     )
+    await expect(
+      mdxContent.getByRole("table", { name: "AI pipeline failure modes" }),
+    ).toBeVisible()
   })
 })


### PR DESCRIPTION
## Summary

- add one statically imported MDX article at the existing `/blog/ai-pipelines-need-control-boundaries` URL
- keep Markdown body and frontmatter together in a sibling `content.mdx` build input
- use a static route wrapper for validation, SEO, JSON-LD, layout, and approved component injection
- extract the existing article chrome into `BlogArticleLayout` and reuse it for all TSX posts
- expose only `Callout`, `Figure`, `ControlTable`, and `PostLink` to the representative MDX body
- validate required frontmatter, date format, duplicate arrays, route/slug parity, and temporary registry metadata parity
- add JavaScript-enabled, client-navigation, semantic-table, metadata, and JavaScript-disabled browser contracts

## Architecture

The route uses a route folder:

```text
app/routes/blog.ai-pipelines-need-control-boundaries/
  route.tsx
  content.mdx
```

`route.tsx` statically imports `content.mdx`. There is no render-time dynamic import, filesystem read, parser, or compiler. The MDX body contains no imports or exports; the route injects the approved component vocabulary.

The existing TSX registry remains temporarily authoritative for blog-index and series discovery. The route performs module-load parity checks between MDX frontmatter and the registry so metadata cannot silently diverge during this vertical slice.

## Table decision

The current native Remix MDX pipeline does not enable GitHub-Flavored Markdown table parsing. The first browser run showed that a pipe table rendered as paragraph text. Rather than add a broad parser dependency for one slice or silently accept incorrect markup, this PR adds a narrowly approved `ControlTable` component. The article keeps its row data in MDX while the component guarantees semantic `table`, `thead`, row-header, and cell markup with horizontal overflow support.

## Representative coverage

The selected article exercises:

- frontmatter metadata
- headings and lists
- a callout component
- a static figure
- a semantic data table
- a cross-post link
- related-post and series layout
- canonical metadata and Article JSON-LD
- direct SSR with JavaScript disabled
- hydrated client navigation

## Validation

Successful required CI run: `30866560868`

### Quality — passed

- frozen dependency install with no package or lockfile changes
- full-repository Prettier and ESLint
- TypeScript build
- native Remix MDX compilation
- production Remix build
- pinned Wrangler Pages Function build
- raw/gzip Worker bundle-budget enforcement
- direct Pages adapter contract
- source-isolated asset-first workerd runtime contract
- runtime manifest and Worker artifact upload

### End-to-end — passed

- complete functional Playwright suite on desktop and mobile Chromium
- representative MDX component and metadata checks
- semantic accessible table checks
- hydrated cross-post navigation
- JavaScript-disabled complete article rendering
- no failure artifacts

## Worker delta

| Measurement | Baseline | Current | Delta |
| --- | ---: | ---: | ---: |
| Raw Worker | 2,356,613 bytes | 2,382,249 bytes | +25,636 bytes |
| Gzip Worker | 466,338 bytes | 473,501 bytes | +7,163 bytes |

Both measurements remain well within the enforced repository budgets.

## Intentional limitation

This vertical slice changes the rendered route to canonical MDX but does not yet delete the selected article's legacy TSX body from `app/content/blog.tsx`. The temporary duplicate remains because the current registry combines discovery metadata and render components. The next #55 slice must separate registry metadata from article bodies, remove the duplicate TSX content, and derive or validate discovery metadata from canonical frontmatter before bulk migration.

Progresses #55; does not close it.