### PR TITLE
Restore the Remix client runtime safely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
   end-to-end:
     name: End-to-end
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
 
     steps:
       - name: Check out repository
@@ -123,6 +123,9 @@ jobs:
       - name: Run functional Playwright tests
         run: yarn playwright test --grep-invert "visual regressions"
 
+      - name: Run Cloudflare hydration browser contracts
+        run: yarn test:e2e:cloudflare
+
       - name: Upload Playwright failure artifacts
         if: failure()
         uses: actions/upload-artifact@v4
@@ -130,6 +133,8 @@ jobs:
           name: playwright-failure-${{ github.run_id }}
           path: |
             playwright-report
+            playwright-report-cloudflare
             test-results
+            test-results-cloudflare
           if-no-files-found: ignore
           retention-days: 7

--- a/app/client/mermaid.client.ts
+++ b/app/client/mermaid.client.ts
@@ -1,0 +1,25 @@
+import mermaid from "mermaid"
+
+const MERMAID_READY_EVENT = "micrantha:mermaid-ready"
+
+export function installMermaidRenderer() {
+  if (window.__micranthaRenderMermaid) return
+
+  mermaid.initialize({
+    startOnLoad: false,
+    securityLevel: "strict",
+    theme: "neutral",
+    themeCSS: `
+      .nodeLabel p {
+        font-size: 16px;
+        line-height: 1.5;
+      }
+    `,
+  })
+
+  window.__micranthaRenderMermaid = async (id, chart) => {
+    const result = await mermaid.render(id, chart)
+    return result.svg
+  }
+  window.dispatchEvent(new Event(MERMAID_READY_EVENT))
+}

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -11,21 +11,31 @@ export const Footer = () => {
 
   useEffect(() => {
     let isActive = true
+    let timeoutId: number | null = null
 
-    void fetch("/api/fortune")
-      .then(async (response) => {
-        if (!response.ok) return null
-        return (await response.json()) as FortuneResponse
-      })
-      .then((data) => {
-        if (isActive && data?.text) {
-          setFortune(data.text)
-        }
-      })
-      .catch(() => {})
+    const frameId = window.requestAnimationFrame(() => {
+      timeoutId = window.setTimeout(() => {
+        void fetch("/api/fortune")
+          .then(async (response) => {
+            if (!response.ok) return null
+            return (await response.json()) as FortuneResponse
+          })
+          .then((data) => {
+            if (isActive && data?.text) {
+              setFortune(data.text)
+            }
+          })
+          .catch(() => {})
+      }, 0)
+    })
 
     return () => {
       isActive = false
+      window.cancelAnimationFrame(frameId)
+
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId)
+      }
     }
   }, [])
 
@@ -44,13 +54,15 @@ export const Footer = () => {
 
         {fortune ? (
           <div className="max-w-3xl text-sm text-gray-700">
-            <span aria-hidden="true">&#10077;</span> {fortune}{" "}
-            <span aria-hidden="true">&#10078;</span>
+            <p>
+              <span aria-hidden="true">&#10077;</span> {fortune}{" "}
+              <span aria-hidden="true">&#10078;</span>
+            </p>
           </div>
         ) : null}
 
         <div className="text-sm text-gray-600">
-          &copy; All Rights Reserved{" "}
+          <span>© All Rights Reserved</span>{" "}
           <ExternalLink href="https://micrantha.com">
             Micrantha Software
           </ExternalLink>

--- a/app/components/mermaid-diagram.tsx
+++ b/app/components/mermaid-diagram.tsx
@@ -1,12 +1,67 @@
+import { useEffect, useId, useState } from "react"
+
 type MermaidDiagramProps = {
   title: string
   caption?: string
   chart: string
 }
 
+const MERMAID_READY_EVENT = "micrantha:mermaid-ready"
+
+declare global {
+  interface Window {
+    __micranthaRenderMermaid?: (id: string, chart: string) => Promise<string>
+  }
+}
+
 export function MermaidDiagram({ title, caption, chart }: MermaidDiagramProps) {
+  const reactId = useId()
+  const diagramId = `mermaid-${reactId.replace(/[^a-zA-Z0-9_-]/g, "")}`
+  const [svg, setSvg] = useState<string | null>(null)
+  const [failed, setFailed] = useState(false)
+
+  useEffect(() => {
+    let active = true
+
+    setSvg(null)
+    setFailed(false)
+
+    const render = () => {
+      const renderer = window.__micranthaRenderMermaid
+
+      if (!renderer) return
+
+      void renderer(diagramId, chart)
+        .then((renderedSvg) => {
+          if (active) {
+            setSvg(renderedSvg)
+          }
+        })
+        .catch(() => {
+          if (active) {
+            setFailed(true)
+          }
+        })
+    }
+
+    if (window.__micranthaRenderMermaid) {
+      render()
+    } else {
+      window.addEventListener(MERMAID_READY_EVENT, render, { once: true })
+    }
+
+    return () => {
+      active = false
+      window.removeEventListener(MERMAID_READY_EVENT, render)
+    }
+  }, [chart, diagramId])
+
   return (
-    <figure className="article-diagram mb-10" data-mermaid-diagram>
+    <figure
+      className="article-diagram mb-10"
+      data-mermaid-diagram
+      data-mermaid-status={svg ? "rendered" : failed ? "error" : "source"}
+    >
       <figcaption className="article-diagram-caption">
         <span className="article-diagram-title">{title}</span>
         {caption ? (
@@ -14,12 +69,22 @@ export function MermaidDiagram({ title, caption, chart }: MermaidDiagramProps) {
         ) : null}
       </figcaption>
 
-      <pre
-        className="overflow-x-auto rounded-2xl p-4 text-sm leading-7 text-slate-700"
-        data-mermaid-source
-      >
-        {chart}
-      </pre>
+      {svg ? (
+        <div
+          className="overflow-x-auto rounded-2xl p-4"
+          data-mermaid-rendered
+          dangerouslySetInnerHTML={{ __html: svg }}
+        />
+      ) : (
+        <pre
+          className={`overflow-x-auto rounded-2xl p-4 text-sm leading-7 ${
+            failed ? "text-slate-100" : "text-slate-700"
+          }`}
+          data-mermaid-source
+        >
+          {chart}
+        </pre>
+      )}
     </figure>
   )
 }

--- a/app/components/navigation.tsx
+++ b/app/components/navigation.tsx
@@ -82,6 +82,7 @@ export const Navigation = () => {
         <details data-mobile-navigation className="group relative sm:hidden">
           <summary
             aria-controls={MOBILE_NAVIGATION_ID}
+            aria-expanded="false"
             className="flex h-11 w-11 list-none items-center justify-center rounded-lg border border-slate-200 text-slate-700 transition-colors hover:bg-slate-50 [&::-webkit-details-marker]:hidden"
           >
             <span className="sr-only">Navigation menu</span>

--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -1,54 +1,21 @@
 import { RemixBrowser } from "@remix-run/react"
+import { startTransition } from "react"
 import { hydrateRoot } from "react-dom/client"
 
-// Temporary production hardening: disable hydration until SSR/client mismatch is fully root-caused.
-const ENABLE_HYDRATION = false
-
-async function renderMermaidDiagrams() {
-  const diagramFigures = Array.from(
-    document.querySelectorAll<HTMLElement>("[data-mermaid-diagram]"),
-  )
-
-  if (diagramFigures.length === 0) return
-
-  const mermaid = (await import("mermaid")).default
-
-  mermaid.initialize({
-    startOnLoad: false,
-    securityLevel: "strict",
-    theme: "neutral",
-    themeCSS: `
-      .nodeLabel p {
-        font-size: 16px;
-        line-height: 1.5;
-      }
-    `,
+startTransition(() => {
+  hydrateRoot(document, <RemixBrowser />, {
+    onRecoverableError(error, errorInfo) {
+      console.error(
+        "Recoverable React hydration error",
+        error,
+        errorInfo.componentStack,
+      )
+    },
   })
+})
 
-  await Promise.all(
-    diagramFigures.map(async (figure, index) => {
-      const source = figure.querySelector<HTMLElement>("[data-mermaid-source]")
-      const chart = source?.textContent?.trim()
-
-      if (!source || !chart) return
-
-      try {
-        const result = await mermaid.render(`mermaid-${index}`, chart)
-        const container = document.createElement("div")
-
-        container.className = "overflow-x-auto rounded-2xl p-4"
-        container.innerHTML = result.svg
-        source.replaceWith(container)
-      } catch {
-        source.className =
-          "overflow-x-auto rounded-2xl p-4 text-sm leading-7 text-slate-100"
-      }
-    }),
-  )
-}
-
-void renderMermaidDiagrams()
-
-if (ENABLE_HYDRATION) {
-  hydrateRoot(document, <RemixBrowser />)
-}
+void import("./client/mermaid.client")
+  .then(({ installMermaidRenderer }) => installMermaidRenderer())
+  .catch((error) => {
+    console.error("Failed to initialize Mermaid rendering", error)
+  })

--- a/e2e/hydration.spec.ts
+++ b/e2e/hydration.spec.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "@playwright/test"
+import type { Page } from "@playwright/test"
+
+type BrowserFailure = {
+  kind: "console" | "pageerror"
+  message: string
+}
+
+function captureBrowserFailures(page: Page) {
+  const failures: BrowserFailure[] = []
+
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      failures.push({ kind: "console", message: message.text() })
+    }
+  })
+  page.on("pageerror", (error) => {
+    failures.push({ kind: "pageerror", message: error.message })
+  })
+
+  return () => expect(failures).toEqual([])
+}
+
+test("React effects run and Remix navigation preserves the document", async ({
+  page,
+}, testInfo) => {
+  test.skip(
+    testInfo.project.name === "mobile-chromium",
+    "One hydrated browser project is sufficient for the client-runtime contract.",
+  )
+
+  const assertNoBrowserFailures = captureBrowserFailures(page)
+  const fortune = "Hydration effects are active."
+
+  await page.route("**/api/fortune", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ text: fortune }),
+    }),
+  )
+  await page.goto("/")
+  await expect(page.getByText(fortune)).toBeVisible()
+
+  const documentIdentity = await page.evaluate(() => {
+    const identity = globalThis.crypto.randomUUID()
+    Object.defineProperty(globalThis, "__micranthaDocumentIdentity", {
+      configurable: true,
+      value: identity,
+    })
+    return identity
+  })
+
+  await page
+    .getByRole("navigation", { name: "Primary" })
+    .getByRole("link", { name: "Solutions", exact: true })
+    .click()
+
+  await expect(page).toHaveURL(/\/solutions$/)
+  await expect(
+    page
+      .getByRole("navigation", { name: "Primary" })
+      .getByRole("link", { name: "Solutions", exact: true }),
+  ).toHaveAttribute("aria-current", "page")
+  expect(
+    await page.evaluate(() =>
+      Reflect.get(globalThis, "__micranthaDocumentIdentity"),
+    ),
+  ).toBe(documentIdentity)
+  assertNoBrowserFailures()
+})
+
+test("Mermaid enhances only after hydration without browser errors", async ({
+  page,
+}, testInfo) => {
+  test.skip(
+    testInfo.project.name === "mobile-chromium",
+    "One hydrated browser project is sufficient for the Mermaid contract.",
+  )
+
+  const assertNoBrowserFailures = captureBrowserFailures(page)
+
+  await page.goto("/blog/governance-native-engineering-control-plane")
+
+  const diagram = page.locator("[data-mermaid-diagram]").first()
+  await expect(diagram).toHaveAttribute("data-mermaid-status", "rendered", {
+    timeout: 15_000,
+  })
+  await expect(diagram.locator("[data-mermaid-rendered] svg")).toBeVisible()
+  await expect(diagram.locator("[data-mermaid-source]")).toHaveCount(0)
+  assertNoBrowserFailures()
+})
+
+test("core article content remains usable without JavaScript", async ({
+  browser,
+}, testInfo) => {
+  test.skip(
+    testInfo.project.name === "mobile-chromium",
+    "One JavaScript-disabled browser project is sufficient for the SSR contract.",
+  )
+
+  const baseURL = String(testInfo.project.use.baseURL)
+  const context = await browser.newContext({
+    baseURL,
+    javaScriptEnabled: false,
+  })
+  const page = await context.newPage()
+
+  try {
+    await page.goto("/blog/governance-native-engineering-control-plane")
+    await expect(
+      page.getByRole("heading", {
+        name: "Governance-Native Engineering and the AI Control Plane",
+      }),
+    ).toBeVisible()
+
+    const diagram = page.locator("[data-mermaid-diagram]").first()
+    await expect(diagram).toHaveAttribute("data-mermaid-status", "source")
+    await expect(diagram.locator("[data-mermaid-source]")).toContainText(
+      "Human intent",
+    )
+
+    await page
+      .getByRole("navigation", { name: "Primary" })
+      .getByRole("link", { name: "Solutions", exact: true })
+      .click()
+    await expect(page).toHaveURL(/\/solutions$/)
+    await expect(
+      page.getByRole("heading", { name: "Solutions", level: 1 }),
+    ).toBeVisible()
+    await expect(
+      page.getByText(
+        "Deployable systems, distributions, tools, and platforms.",
+      ),
+    ).toBeVisible()
+  } finally {
+    await context.close()
+  }
+})

--- a/functions/[[path]].js
+++ b/functions/[[path]].js
@@ -3,4 +3,26 @@ import * as build from "../build/index.js"
 
 const handleRequest = createRequestHandler(build)
 
-export const onRequest = (context) => handleRequest(context.request, context)
+function ensureHtmlCharset(response) {
+  const contentType = response.headers.get("Content-Type")
+
+  if (
+    !contentType ||
+    !/^text\/html(?:;|$)/i.test(contentType) ||
+    /(?:^|;)\s*charset=/i.test(contentType)
+  ) {
+    return response
+  }
+
+  const headers = new Headers(response.headers)
+  headers.set("Content-Type", `${contentType}; charset=utf-8`)
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}
+
+export const onRequest = async (context) =>
+  ensureHtmlCharset(await handleRequest(context.request, context))

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:cloudflare:bundle-budget": "node scripts/check-cloudflare-bundle-budget.js",
     "test:cloudflare:runtime": "node scripts/stage-cloudflare-runtime.js && node scripts/test-cloudflare-runtime.js",
     "test:e2e": "playwright test",
+    "test:e2e:cloudflare": "playwright test --config playwright.cloudflare.config.ts",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:mobile": "playwright test --project=mobile-chromium",
     "typecheck": "tsc -b",

--- a/playwright.cloudflare.config.ts
+++ b/playwright.cloudflare.config.ts
@@ -1,0 +1,64 @@
+import fs from "node:fs"
+import { defineConfig, devices } from "@playwright/test"
+
+const chromiumExecutablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+  ? process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+  : fs.existsSync("/usr/bin/chromium")
+    ? "/usr/bin/chromium"
+    : undefined
+const port = Number(process.env.CLOUDFLARE_PLAYWRIGHT_PORT ?? 8788)
+const baseURL = `http://127.0.0.1:${port}`
+
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: "hydration.spec.ts",
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  outputDir: "test-results-cloudflare",
+  reporter: process.env.CI
+    ? [
+        ["list"],
+        [
+          "html",
+          {
+            outputFolder: "playwright-report-cloudflare",
+            open: "never",
+          },
+        ],
+      ]
+    : "list",
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+    launchOptions: chromiumExecutablePath
+      ? { executablePath: chromiumExecutablePath }
+      : undefined,
+  },
+  webServer: {
+    command: [
+      "yarn build",
+      "yarn cloudflare:functions:build",
+      "yarn cloudflare:runtime:stage",
+      `yarn wrangler --cwd .cloudflare/runtime dev --config wrangler.toml --no-bundle --ip 127.0.0.1 --port ${port} --local-protocol http --show-interactive-dev-session=false`,
+    ].join(" && "),
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 120_000,
+    env: {
+      CI: "true",
+      NO_COLOR: "1",
+      WRANGLER_SEND_METRICS: "false",
+    },
+  },
+  projects: [
+    {
+      name: "cloudflare-chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+})

--- a/scripts/test-cloudflare-adapter.js
+++ b/scripts/test-cloudflare-adapter.js
@@ -42,7 +42,10 @@ async function read(pathname, options) {
 }
 
 function assertDocumentHeaders(response, body, { requireNonce = true } = {}) {
-  assert.match(response.headers.get("content-type") ?? "", /^text\/html\b/)
+  assert.match(
+    response.headers.get("content-type") ?? "",
+    /^text\/html;\s*charset=utf-8$/i,
+  )
   assert.equal(response.headers.get("x-content-type-options"), "nosniff")
   assert.equal(response.headers.get("x-frame-options"), "DENY")
   assert.equal(


### PR DESCRIPTION
## Summary

- restore Remix hydration on current `main`
- move Mermaid enhancement behind component-local post-hydration effects
- preserve complete server-rendered and JavaScript-disabled diagram source
- keep native mobile navigation markup deterministic before React attaches
- make the Cloudflare Pages adapter declare UTF-8 for every HTML document
- add browser contracts for React effects, client-side Remix navigation, active-route updates, Mermaid enhancement, browser errors, and JavaScript-disabled fallbacks
- run the contracts through both `remix-serve` and the source-isolated asset-first workerd runtime

## Regression diagnosis

The original footer mismatch was specific to the Cloudflare production path. The Pages Function adapter returned `Content-Type: text/html` without a charset and the document had no early charset declaration. Chromium therefore decoded UTF-8 non-ASCII text using its legacy HTML fallback before React attached; the footer copyright symbol became a different text node than the client expected. React reported the footer mismatch first, then emitted cascading document-level recovery errors for scripts and preload links.

The adapter now normalizes rendered HTML responses to `text/html; charset=utf-8`. The adapter contract requires that header for successful documents and rendered error responses, while the workerd Playwright suite verifies that real Chromium hydration completes without console or page errors.

## Scope

Closes #76.
Supersedes #92.

## Validation

CI run `30873347459` passed both required jobs on head `ef4f220dc33c8b6e2faeb53e05753705cbb5d139`:

- formatting, lint, content-boundary validation, typecheck, and production build
- pinned Wrangler verification and Worker bundle budget
- Cloudflare Pages adapter and source-isolated workerd runtime contracts
- complete desktop/mobile functional Playwright suite
- Cloudflare workerd hydration, Mermaid enhancement, client navigation, and JavaScript-disabled browser contracts
