### PR TITLE
Enforce the approved blog MDX grammar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Lint repository
         run: yarn lint
 
+      - name: Test blog MDX grammar validator
+        run: yarn test:blog-mdx-validation
+
       - name: Validate blog content boundaries
         run: yarn test:blog-content-boundaries
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint:fix": "eslint --fix .",
     "start": "remix-serve build/index.js",
     "test:blog-content-boundaries": "node scripts/check-blog-content-boundaries.js",
+    "test:blog-mdx-validation": "node scripts/test-blog-mdx-validation.js",
     "test:cloudflare:adapter": "node scripts/test-cloudflare-adapter.js",
     "test:cloudflare:bundle-budget": "node scripts/check-cloudflare-bundle-budget.js",
     "test:cloudflare:runtime": "node scripts/stage-cloudflare-runtime.js && node scripts/test-cloudflare-runtime.js",
@@ -28,7 +29,7 @@
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:mobile": "playwright test --project=mobile-chromium",
     "typecheck": "tsc -b",
-    "deploy:cloudflare": "yarn test:blog-content-boundaries && yarn typecheck && yarn build && yarn cloudflare:functions:build && yarn test:cloudflare:bundle-budget && yarn test:cloudflare:adapter && yarn test:cloudflare:runtime && wrangler pages deploy public --project-name ${CLOUDFLARE_PAGES_PROJECT:-micrantha-web} --branch ${CLOUDFLARE_PAGES_BRANCH:-main} --upload-source-maps"
+    "deploy:cloudflare": "yarn test:blog-mdx-validation && yarn test:blog-content-boundaries && yarn typecheck && yarn build && yarn cloudflare:functions:build && yarn test:cloudflare:bundle-budget && yarn test:cloudflare:adapter && yarn test:cloudflare:runtime && wrangler pages deploy public --project-name ${CLOUDFLARE_PAGES_PROJECT:-micrantha-web} --branch ${CLOUDFLARE_PAGES_BRANCH:-main} --upload-source-maps"
   },
   "dependencies": {
     "@remix-run/node": "2.17.4",
@@ -44,6 +45,7 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.10.2",
     "@eslint/compat": "2.0.3",
+    "@mdx-js/mdx": "^2.3.0",
     "@playwright/test": "^1.54.2",
     "@remix-run/dev": "2.17.4",
     "@remix-run/eslint-config": "2.17.4",

--- a/scripts/blog-mdx-validation.js
+++ b/scripts/blog-mdx-validation.js
@@ -19,9 +19,7 @@ const allowedComponents = new Set([
 
 function contextFor(relativePath, node) {
   const start = node?.position?.start
-  return start
-    ? `${relativePath}:${start.line}:${start.column}`
-    : relativePath
+  return start ? `${relativePath}:${start.line}:${start.column}` : relativePath
 }
 
 function stripFrontmatter(source, relativePath) {
@@ -44,7 +42,11 @@ function stripFrontmatter(source, relativePath) {
 }
 
 function assertSafeLinkUrl(url, context) {
-  assert.equal(url, url.trim(), `${context} URL must not contain outer whitespace`)
+  assert.equal(
+    url,
+    url.trim(),
+    `${context} URL must not contain outer whitespace`,
+  )
   assert.notEqual(url, "", `${context} URL must not be empty`)
   assert.equal(
     /[\u0000-\u001f\u007f]/u.test(url),

--- a/scripts/blog-mdx-validation.js
+++ b/scripts/blog-mdx-validation.js
@@ -41,6 +41,13 @@ function stripFrontmatter(source, relativePath) {
   return normalized.slice(closingDelimiter + "\n---\n".length)
 }
 
+function hasControlCharacter(value) {
+  return [...value].some((character) => {
+    const codePoint = character.codePointAt(0)
+    return codePoint <= 0x1f || codePoint === 0x7f
+  })
+}
+
 function assertSafeLinkUrl(url, context) {
   assert.equal(
     url,
@@ -49,7 +56,7 @@ function assertSafeLinkUrl(url, context) {
   )
   assert.notEqual(url, "", `${context} URL must not be empty`)
   assert.equal(
-    /[\u0000-\u001f\u007f]/u.test(url),
+    hasControlCharacter(url),
     false,
     `${context} URL contains control characters`,
   )

--- a/scripts/blog-mdx-validation.js
+++ b/scripts/blog-mdx-validation.js
@@ -1,0 +1,441 @@
+import assert from "node:assert/strict"
+import { readFile, stat } from "node:fs/promises"
+import path from "node:path"
+
+import { createProcessor } from "@mdx-js/mdx"
+import ts from "typescript"
+
+import { repositoryRoot } from "./blog-content-inventory.js"
+
+const mdxProcessor = createProcessor({ format: "mdx" })
+const publicDirectory = path.join(repositoryRoot, "public")
+
+const allowedComponents = new Set([
+  "Callout",
+  "ControlTable",
+  "Figure",
+  "PostLink",
+])
+
+function contextFor(relativePath, node) {
+  const start = node?.position?.start
+  return start
+    ? `${relativePath}:${start.line}:${start.column}`
+    : relativePath
+}
+
+function stripFrontmatter(source, relativePath) {
+  const normalized = source.replaceAll("\r\n", "\n")
+
+  assert.ok(
+    normalized.startsWith("---\n"),
+    `${relativePath} must begin with YAML frontmatter`,
+  )
+
+  const closingDelimiter = normalized.indexOf("\n---\n", 4)
+
+  assert.notEqual(
+    closingDelimiter,
+    -1,
+    `${relativePath} is missing its closing frontmatter delimiter`,
+  )
+
+  return normalized.slice(closingDelimiter + "\n---\n".length)
+}
+
+function assertSafeLinkUrl(url, context) {
+  assert.equal(url, url.trim(), `${context} URL must not contain outer whitespace`)
+  assert.notEqual(url, "", `${context} URL must not be empty`)
+  assert.equal(
+    /[\u0000-\u001f\u007f]/u.test(url),
+    false,
+    `${context} URL contains control characters`,
+  )
+  assert.equal(
+    url.includes("\\"),
+    false,
+    `${context} URL must not contain backslashes`,
+  )
+
+  if (url.startsWith("#")) {
+    assert.ok(url.length > 1, `${context} fragment must not be empty`)
+    return
+  }
+
+  if (url.startsWith("/")) {
+    assert.equal(
+      url.startsWith("//"),
+      false,
+      `${context} URL must not be protocol-relative`,
+    )
+    assert.equal(
+      url.split(/[?#]/u)[0].split("/").includes(".."),
+      false,
+      `${context} URL must not traverse parent directories`,
+    )
+    return
+  }
+
+  const parsed = new URL(url)
+  assert.ok(
+    ["http:", "https:", "mailto:"].includes(parsed.protocol),
+    `${context} uses unsupported protocol ${parsed.protocol}`,
+  )
+}
+
+function assertLocalAssetUrl(url, context) {
+  assert.match(
+    url,
+    /^\/[-A-Za-z0-9_./]+$/u,
+    `${context} must be a root-relative local asset URL`,
+  )
+  assert.equal(
+    url.startsWith("//"),
+    false,
+    `${context} must not be protocol-relative`,
+  )
+  assert.equal(
+    url.split("/").includes(".."),
+    false,
+    `${context} must not traverse parent directories`,
+  )
+}
+
+async function repositoryAssetExists(url) {
+  const absolutePath = path.resolve(publicDirectory, `.${url}`)
+
+  if (
+    absolutePath !== publicDirectory &&
+    !absolutePath.startsWith(`${publicDirectory}${path.sep}`)
+  ) {
+    return false
+  }
+
+  try {
+    return (await stat(absolutePath)).isFile()
+  } catch (error) {
+    if (error?.code === "ENOENT") return false
+    throw error
+  }
+}
+
+function readAttributes(node, relativePath) {
+  const context = contextFor(relativePath, node)
+  const attributes = new Map()
+
+  for (const attribute of node.attributes ?? []) {
+    assert.equal(
+      attribute.type,
+      "mdxJsxAttribute",
+      `${context} does not allow spread or expression attributes`,
+    )
+    assert.equal(
+      typeof attribute.name,
+      "string",
+      `${context} component attribute names must be plain identifiers`,
+    )
+    assert.equal(
+      attributes.has(attribute.name),
+      false,
+      `${context} repeats component attribute ${attribute.name}`,
+    )
+    attributes.set(attribute.name, attribute.value)
+  }
+
+  return attributes
+}
+
+function assertOnlyAttributes(attributes, allowed, context) {
+  for (const name of attributes.keys()) {
+    assert.ok(
+      allowed.has(name),
+      `${context} does not allow component attribute ${name}`,
+    )
+    assert.equal(
+      /^on[A-Z]/u.test(name),
+      false,
+      `${context} does not allow event-handler props`,
+    )
+  }
+}
+
+function requiredStringAttribute(attributes, name, context) {
+  assert.ok(
+    attributes.has(name),
+    `${context} is missing required attribute ${name}`,
+  )
+  const value = attributes.get(name)
+
+  assert.equal(
+    typeof value,
+    "string",
+    `${context}.${name} must be a string literal`,
+  )
+  assert.notEqual(value.trim(), "", `${context}.${name} must not be empty`)
+
+  return value
+}
+
+function parseExpression(expression, context) {
+  const sourceFile = ts.createSourceFile(
+    "blog-mdx-expression.ts",
+    `const value = (${expression})`,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  )
+
+  assert.equal(
+    sourceFile.parseDiagnostics.length,
+    0,
+    `${context} must be valid literal JavaScript`,
+  )
+
+  const statement = sourceFile.statements[0]
+  assert.ok(
+    statement && ts.isVariableStatement(statement),
+    `${context} must be a literal expression`,
+  )
+
+  const initializer = statement.declarationList.declarations[0]?.initializer
+  assert.ok(initializer, `${context} must contain an expression`)
+
+  return ts.isParenthesizedExpression(initializer)
+    ? initializer.expression
+    : initializer
+}
+
+function literalString(node, context) {
+  assert.ok(
+    ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node),
+    `${context} must be a string literal`,
+  )
+  assert.notEqual(node.text.trim(), "", `${context} must not be empty`)
+  return node.text
+}
+
+function validateControlTableRows(expression, context) {
+  const node = parseExpression(expression, context)
+
+  assert.ok(
+    ts.isArrayLiteralExpression(node),
+    `${context} must be an array literal`,
+  )
+  assert.ok(
+    node.elements.length > 0,
+    `${context} must contain at least one row`,
+  )
+
+  const failureModes = []
+
+  for (const [index, element] of node.elements.entries()) {
+    const rowContext = `${context}[${index}]`
+    assert.ok(
+      ts.isObjectLiteralExpression(element),
+      `${rowContext} must be an object literal`,
+    )
+
+    const values = new Map()
+
+    for (const property of element.properties) {
+      assert.ok(
+        ts.isPropertyAssignment(property),
+        `${rowContext} allows only property assignments`,
+      )
+      assert.ok(
+        ts.isIdentifier(property.name) || ts.isStringLiteral(property.name),
+        `${rowContext} property names must be literals`,
+      )
+
+      const name = property.name.text
+      assert.ok(
+        ["failureMode", "cause", "response"].includes(name),
+        `${rowContext} contains unsupported property ${name}`,
+      )
+      assert.equal(
+        values.has(name),
+        false,
+        `${rowContext} repeats property ${name}`,
+      )
+      values.set(
+        name,
+        literalString(property.initializer, `${rowContext}.${name}`),
+      )
+    }
+
+    assert.deepEqual(
+      [...values.keys()].sort(),
+      ["cause", "failureMode", "response"],
+      `${rowContext} must define failureMode, cause, and response`,
+    )
+    failureModes.push(values.get("failureMode"))
+  }
+
+  assert.equal(
+    new Set(failureModes).size,
+    failureModes.length,
+    `${context} contains duplicate failureMode values`,
+  )
+}
+
+async function validateComponent(node, options) {
+  const { assetExists, knownPostSlugs, relativePath } = options
+  const context = contextFor(relativePath, node)
+
+  assert.equal(
+    typeof node.name,
+    "string",
+    `${context} does not allow JSX fragments`,
+  )
+  assert.ok(
+    allowedComponents.has(node.name),
+    `${context} uses unsupported MDX component ${node.name}`,
+  )
+
+  const attributes = readAttributes(node, relativePath)
+
+  if (node.name === "Callout") {
+    assertOnlyAttributes(attributes, new Set(), context)
+    assert.ok(
+      node.children?.length > 0,
+      `${context} Callout must contain content`,
+    )
+    return
+  }
+
+  if (node.name === "PostLink") {
+    assertOnlyAttributes(attributes, new Set(["slug"]), context)
+    const slug = requiredStringAttribute(attributes, "slug", context)
+    assert.ok(
+      knownPostSlugs.has(slug),
+      `${context} references unknown post ${slug}`,
+    )
+    assert.ok(
+      node.children?.length > 0,
+      `${context} PostLink must contain link text`,
+    )
+    return
+  }
+
+  if (node.name === "Figure") {
+    assertOnlyAttributes(
+      attributes,
+      new Set(["alt", "caption", "narrow", "src", "title"]),
+      context,
+    )
+
+    requiredStringAttribute(attributes, "alt", context)
+    requiredStringAttribute(attributes, "caption", context)
+    requiredStringAttribute(attributes, "title", context)
+    const src = requiredStringAttribute(attributes, "src", context)
+
+    if (attributes.has("narrow")) {
+      assert.equal(
+        attributes.get("narrow"),
+        null,
+        `${context}.narrow must use boolean shorthand`,
+      )
+    }
+
+    assert.equal(
+      node.children?.length ?? 0,
+      0,
+      `${context} Figure must be self-closing`,
+    )
+    assertLocalAssetUrl(src, `${context}.src`)
+    assert.equal(
+      await assetExists(src),
+      true,
+      `${context}.src references missing asset ${src}`,
+    )
+    return
+  }
+
+  assertOnlyAttributes(attributes, new Set(["rows"]), context)
+  assert.equal(
+    node.children?.length ?? 0,
+    0,
+    `${context} ControlTable must be self-closing`,
+  )
+  assert.ok(
+    attributes.has("rows"),
+    `${context} is missing required attribute rows`,
+  )
+
+  const rows = attributes.get("rows")
+  assert.equal(
+    rows?.type,
+    "mdxJsxAttributeValueExpression",
+    `${context}.rows must be a controlled array expression`,
+  )
+  validateControlTableRows(rows.value, `${context}.rows`)
+}
+
+async function validateNode(node, options) {
+  const context = contextFor(options.relativePath, node)
+
+  if (node.type === "mdxjsEsm") {
+    assert.fail(`${context} does not allow MDX imports or exports`)
+  }
+
+  if (node.type === "mdxFlowExpression" || node.type === "mdxTextExpression") {
+    assert.fail(`${context} does not allow arbitrary JavaScript expressions`)
+  }
+
+  if (node.type === "html") {
+    assert.fail(`${context} does not allow raw HTML`)
+  }
+
+  if (node.type === "mdxJsxFlowElement" || node.type === "mdxJsxTextElement") {
+    await validateComponent(node, options)
+  }
+
+  if (node.type === "link" || node.type === "definition") {
+    assertSafeLinkUrl(node.url, context)
+  }
+
+  if (node.type === "image") {
+    assertLocalAssetUrl(node.url, context)
+    assert.equal(
+      await options.assetExists(node.url),
+      true,
+      `${context} references missing asset ${node.url}`,
+    )
+  }
+
+  if (node.type === "imageReference") {
+    assert.fail(`${context} does not allow reference-style images`)
+  }
+
+  for (const child of node.children ?? []) {
+    await validateNode(child, options)
+  }
+}
+
+export async function validateBlogMdxSource({
+  assetExists = repositoryAssetExists,
+  knownPostSlugs,
+  relativePath,
+  source,
+}) {
+  assert.ok(knownPostSlugs instanceof Set, "knownPostSlugs must be a Set")
+
+  const body = stripFrontmatter(source, relativePath)
+  const tree = mdxProcessor.parse({ path: relativePath, value: body })
+
+  await validateNode(tree, {
+    assetExists,
+    knownPostSlugs,
+    relativePath,
+  })
+}
+
+export async function validateBlogMdxFile(relativePath, inventory) {
+  const source = await readFile(path.join(repositoryRoot, relativePath), "utf8")
+
+  await validateBlogMdxSource({
+    knownPostSlugs: new Set(inventory.posts.map((post) => post.slug)),
+    relativePath,
+    source,
+  })
+}

--- a/scripts/check-blog-content-boundaries.js
+++ b/scripts/check-blog-content-boundaries.js
@@ -8,6 +8,7 @@ import {
   loadBlogContentInventory,
   repositoryRoot,
 } from "./blog-content-inventory.js"
+import { validateBlogMdxFile } from "./blog-mdx-validation.js"
 
 const routesDirectory = path.join(repositoryRoot, "app/routes")
 const sitemapPath = path.join(repositoryRoot, "public/sitemap.xml")
@@ -22,15 +23,16 @@ async function pathExists(filePath) {
   }
 }
 
-async function discoverMdxSlugs() {
+async function discoverMdxRoutes() {
   const entries = await readdir(routesDirectory, { withFileTypes: true })
-  const slugs = []
+  const routes = []
 
   for (const entry of entries) {
     if (!entry.isDirectory() || !entry.name.startsWith("blog.")) continue
 
     const routeDirectory = path.join(routesDirectory, entry.name)
-    const hasMdx = await pathExists(path.join(routeDirectory, "content.mdx"))
+    const contentPath = path.join(routeDirectory, "content.mdx")
+    const hasMdx = await pathExists(contentPath)
 
     if (!hasMdx) continue
 
@@ -40,25 +42,34 @@ async function discoverMdxSlugs() {
       `MDX route ${entry.name} is missing route.tsx`,
     )
 
-    slugs.push(entry.name.slice("blog.".length))
+    routes.push({
+      relativePath: path.relative(repositoryRoot, contentPath),
+      slug: entry.name.slice("blog.".length),
+    })
   }
 
   assert.equal(
-    new Set(slugs).size,
-    slugs.length,
+    new Set(routes.map((route) => route.slug)).size,
+    routes.length,
     "Static MDX routes contain duplicate slugs",
   )
 
-  return slugs.sort()
+  return routes.sort((left, right) => left.slug.localeCompare(right.slug))
 }
 
 await assertBlogPostContentOptional()
 
-const [mdxSlugs, inventory, currentSitemap] = await Promise.all([
-  discoverMdxSlugs(),
+const [mdxRoutes, inventory, currentSitemap] = await Promise.all([
+  discoverMdxRoutes(),
   loadBlogContentInventory(),
   readFile(sitemapPath, "utf8"),
 ])
+
+await Promise.all(
+  mdxRoutes.map((route) => validateBlogMdxFile(route.relativePath, inventory)),
+)
+
+const mdxSlugs = mdxRoutes.map((route) => route.slug)
 
 for (const slug of mdxSlugs) {
   const post = inventory.postsBySlug.get(slug)
@@ -92,5 +103,5 @@ assert.equal(
 console.log(
   `Blog content boundaries passed: ${inventory.posts.length} post(s), ${inventory.series.length} series, ${mdxSlugs.length} MDX route(s), ${
     inventory.posts.length - mdxSlugs.length
-  } legacy TSX route(s), sitemap current`,
+  } legacy TSX route(s), MDX grammar enforced, sitemap current`,
 )

--- a/scripts/test-blog-mdx-validation.js
+++ b/scripts/test-blog-mdx-validation.js
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict"
+
+import { validateBlogMdxSource } from "./blog-mdx-validation.js"
+
+const knownPostSlugs = new Set(["current-post", "related-post"])
+const relativePath = "app/routes/blog.current-post/content.mdx"
+const frontmatter = `---
+title: Test
+---
+
+`
+
+async function validate(body, assetExists = async () => true) {
+  return validateBlogMdxSource({
+    assetExists,
+    knownPostSlugs,
+    relativePath,
+    source: `${frontmatter}${body}`,
+  })
+}
+
+await validate(`# Heading
+
+<Callout>Govern the boundary.</Callout>
+
+<Figure
+  title="Architecture"
+  caption="A controlled boundary."
+  src="/img/blog/example.svg"
+  alt="A boundary diagram"
+  narrow
+/>
+
+See <PostLink slug="related-post">the related post</PostLink>.
+
+<ControlTable
+  rows={[
+    {
+      failureMode: "Unsafe write",
+      cause: "Missing authorization",
+      response: "Require an approval boundary",
+    },
+  ]}
+/>
+`)
+
+const invalidCases = [
+  ["ESM", "export const unsafe = true", /imports or exports/u],
+  ["expression", "{Date.now()}", /arbitrary JavaScript expressions/u],
+  ["raw element", "<script />", /unsupported MDX component script/u],
+  ["unknown component", "<Widget />", /unsupported MDX component Widget/u],
+  [
+    "event prop",
+    '<Callout onClick="unsafe">Text</Callout>',
+    /does not allow component attribute onClick/u,
+  ],
+  [
+    "unsafe asset URL",
+    '<Figure title="x" caption="x" src="javascript:alert(1)" alt="x" />',
+    /root-relative local asset URL/u,
+  ],
+  [
+    "unknown post",
+    '<PostLink slug="missing">Missing</PostLink>',
+    /unknown post missing/u,
+  ],
+  [
+    "executable table value",
+    '<ControlTable rows={[{ failureMode: makeValue(), cause: "x", response: "x" }]} />',
+    /failureMode must be a string literal/u,
+  ],
+  [
+    "spread prop",
+    "<Callout {...props}>Text</Callout>",
+    /spread or expression attributes/u,
+  ],
+]
+
+for (const [name, body, message] of invalidCases) {
+  await assert.rejects(validate(body), message, name)
+}
+
+await assert.rejects(
+  validate(
+    '<Figure title="x" caption="x" src="/img/blog/missing.svg" alt="x" />',
+    async () => false,
+  ),
+  /references missing asset/u,
+)
+
+console.log(
+  `Blog MDX validation tests passed: 1 valid case, ${invalidCases.length + 1} rejected cases`,
+)


### PR DESCRIPTION
## Summary

- parse every routable blog `content.mdx` file into the MDX mdast during the existing required content-boundary check
- reject MDX ESM, arbitrary body expressions, raw HTML, JSX fragments, spread attributes, unknown components, event props, and unsupported component props
- permit only the injected `Callout`, `Figure`, `PostLink`, and `ControlTable` vocabulary
- require literal component props, known related-post slugs, safe link protocols, root-relative local figure assets, and existing files
- constrain `ControlTable.rows` to a non-empty literal array of exact `{ failureMode, cause, response }` string records
- add positive and negative validator fixtures and run them in required CI and before Cloudflare deployment
- declare the already lockfile-resolved `@mdx-js/mdx` compiler as a direct build-time development dependency

## Security and runtime boundary

The parser runs only in validation/build tooling. It is not imported by Remix routes or the Cloudflare request path. Published MDX remains compiled before deployment and the Worker does not read source content or evaluate external MDX at request time.

## Validation

Successful required CI run: `30877295675` on head `975e544c16f254bb90176c48befd221ab221985c`.

### Quality — passed

- frozen lockfile install, formatting, and lint
- validator positive fixture and ten rejection cases
- real representative MDX article, cross-post target, structured table expression, and local figure validation
- metadata, series, and sitemap boundaries
- typecheck and production Remix build
- pinned Wrangler, Worker bundle budget, direct adapter, and source-isolated workerd runtime

### End-to-end — passed

- complete desktop/mobile functional Chromium suite
- Cloudflare hydration and JavaScript-disabled browser contracts
- no failure artifacts

Progresses #55; does not close it.