### PR TITLE
Enforce structural blog publication policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile --non-interactive
 
+      - name: Run unit tests with coverage thresholds
+        run: yarn test:unit
+
       - name: Check repository formatting
         id: formatting
         run: yarn format:check
@@ -88,11 +91,8 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-      - name: Test Cloudflare Pages adapter contract
-        run: yarn test:cloudflare:adapter
-
-      - name: Test Cloudflare Pages runtime contract
-        run: yarn test:cloudflare:runtime
+      - name: Run Cloudflare integration tests
+        run: yarn test:integration
 
       - name: Upload Cloudflare runtime manifest
         if: always()

--- a/app/content/blog-provider.ts
+++ b/app/content/blog-provider.ts
@@ -1,13 +1,17 @@
 import type { BlogPost } from "~/content/blog"
 import { blogPosts } from "~/content/blog"
 import { governanceNativeBlogPosts } from "~/content/blog-governance-native"
+import { filterPublishedBlogPosts } from "~/content/blog-publication.js"
 
 export interface BlogContentProvider {
   getPosts(): BlogPost[]
   getPostBySlug(slug: string): BlogPost | null
 }
 
-const tsxBlogPosts: BlogPost[] = [...governanceNativeBlogPosts, ...blogPosts]
+const tsxBlogPosts: BlogPost[] = filterPublishedBlogPosts([
+  ...governanceNativeBlogPosts,
+  ...blogPosts,
+])
 
 export const tsxBlogProvider: BlogContentProvider = {
   getPosts() {

--- a/app/content/blog-publication.js
+++ b/app/content/blog-publication.js
@@ -1,0 +1,148 @@
+const CALENDAR_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
+export const BLOG_PUBLICATION_STATUSES = Object.freeze(["draft", "published"])
+
+export const blogPublicationManifest = Object.freeze({
+  "governance-native-engineering-control-plane": Object.freeze({
+    status: "published",
+  }),
+  "replayability-is-a-governance-problem": Object.freeze({
+    status: "published",
+  }),
+  "recursive-governance-and-agent-workflows": Object.freeze({
+    status: "published",
+  }),
+  "secure-platform-integration-is-not-plumbing": Object.freeze({
+    status: "published",
+  }),
+  "ai-pipelines-need-control-boundaries": Object.freeze({
+    status: "published",
+  }),
+  "software-layers-are-risk-boundaries": Object.freeze({
+    status: "published",
+  }),
+})
+
+export function isCalendarDate(value) {
+  if (typeof value !== "string" || !CALENDAR_DATE_PATTERN.test(value)) {
+    return false
+  }
+
+  const parsed = new Date(`${value}T00:00:00Z`)
+
+  return (
+    !Number.isNaN(parsed.valueOf()) &&
+    parsed.toISOString().slice(0, 10) === value
+  )
+}
+
+export function resolvePublicationCutoff(value, now = new Date()) {
+  const cutoff = value ?? now.toISOString().slice(0, 10)
+
+  if (!isCalendarDate(cutoff)) {
+    throw new Error("Blog publication cutoff must be a valid YYYY-MM-DD date")
+  }
+
+  return cutoff
+}
+
+export function getBlogPublicationStatus(
+  slug,
+  manifest = blogPublicationManifest,
+) {
+  return manifest[slug]?.status ?? null
+}
+
+export function isPublishedBlogPost(post, manifest = blogPublicationManifest) {
+  return getBlogPublicationStatus(post.slug, manifest) === "published"
+}
+
+export function filterPublishedBlogPosts(
+  posts,
+  manifest = blogPublicationManifest,
+) {
+  return posts.filter((post) => isPublishedBlogPost(post, manifest))
+}
+
+function assertKnownStatus(status, context) {
+  if (!BLOG_PUBLICATION_STATUSES.includes(status)) {
+    throw new Error(`${context} has unsupported publication status ${status}`)
+  }
+}
+
+function assertRoutableRecord(post, manifest, cutoff, context) {
+  if (!post || typeof post.slug !== "string" || post.slug.trim() === "") {
+    throw new Error(`${context} must have a non-empty slug`)
+  }
+
+  if (!isCalendarDate(post.date)) {
+    throw new Error(`${context} must have a valid YYYY-MM-DD date`)
+  }
+
+  const status = getBlogPublicationStatus(post.slug, manifest)
+
+  if (status === null) {
+    throw new Error(`${context} is missing publication metadata`)
+  }
+
+  assertKnownStatus(status, context)
+
+  if (status !== "published") {
+    throw new Error(`${context} is ${status} but remains routable`)
+  }
+
+  if (post.date > cutoff) {
+    throw new Error(
+      `${context} is dated ${post.date}, after publication cutoff ${cutoff}`,
+    )
+  }
+}
+
+export function assertRoutableBlogPublication(
+  posts,
+  {
+    manifest = blogPublicationManifest,
+    cutoff = resolvePublicationCutoff(),
+  } = {},
+) {
+  const routableSlugs = new Set()
+
+  for (const [index, post] of posts.entries()) {
+    const context = `Blog post ${post?.slug ?? index}`
+
+    if (post?.slug && routableSlugs.has(post.slug)) {
+      throw new Error(`Duplicate routable blog slug ${post.slug}`)
+    }
+
+    assertRoutableRecord(post, manifest, cutoff, context)
+    routableSlugs.add(post.slug)
+  }
+
+  for (const [slug, publication] of Object.entries(manifest)) {
+    assertKnownStatus(publication?.status, `Publication entry ${slug}`)
+
+    if (publication.status === "published" && !routableSlugs.has(slug)) {
+      throw new Error(
+        `Published publication entry ${slug} is missing routable metadata`,
+      )
+    }
+  }
+
+  return posts
+}
+
+export function assertRoutableMdxPublication(
+  post,
+  {
+    manifest = blogPublicationManifest,
+    cutoff = resolvePublicationCutoff(),
+  } = {},
+) {
+  assertRoutableRecord(post, manifest, cutoff, `MDX route ${post?.slug ?? ""}`)
+
+  if (post.status !== "published") {
+    throw new Error(`MDX route ${post.slug} must declare status published`)
+  }
+
+  return post
+}

--- a/app/routes/blog.ai-pipelines-need-control-boundaries/content.mdx
+++ b/app/routes/blog.ai-pipelines-need-control-boundaries/content.mdx
@@ -3,6 +3,7 @@ slug: ai-pipelines-need-control-boundaries
 title: AI Pipelines Need Control Boundaries
 description: Enterprise AI should be treated as an untrusted reasoning component inside a governed integration path.
 date: "2026-04-24"
+status: published
 excerpt: Enterprise AI becomes safer and more useful when normalization, authorization, validation, and write-back controls are explicit around it.
 tags:
   - architecture-notes

--- a/app/routes/blog.ai-pipelines-need-control-boundaries/route.tsx
+++ b/app/routes/blog.ai-pipelines-need-control-boundaries/route.tsx
@@ -4,6 +4,7 @@ import { BlogArticleLayout } from "~/components/blog-article-layout"
 import { blogMdxComponents } from "~/components/blog-mdx-components"
 import type { BlogPost } from "~/content/blog"
 import { getBlogPostBySlug } from "~/content/blog-provider"
+import { assertRoutableMdxPublication } from "~/content/blog-publication.js"
 import { buildArticleMeta, buildArticleStructuredData } from "~/utils/seo"
 
 import Content, { attributes } from "./content.mdx"
@@ -67,6 +68,7 @@ function requiredSeries() {
 
 const slug = requiredString("slug")
 const date = requiredString("date")
+const status = requiredString("status")
 
 if (slug !== EXPECTED_SLUG) {
   throw new Error(`MDX slug ${slug} does not match route ${EXPECTED_SLUG}`)
@@ -75,6 +77,11 @@ if (slug !== EXPECTED_SLUG) {
 if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || Number.isNaN(Date.parse(date))) {
   throw new Error(`Invalid MDX publication date: ${date}`)
 }
+
+// The build validator owns the target-date cutoff. The route module validates
+// status and manifest parity without recomputing a wall-clock value in the
+// browser, which keeps scheduled preview hydration deterministic.
+assertRoutableMdxPublication({ slug, date, status }, { cutoff: date })
 
 const post: BlogPost = {
   slug,

--- a/docs/architecture/blog-publication-workflow.md
+++ b/docs/architecture/blog-publication-workflow.md
@@ -1,0 +1,83 @@
+# Blog publication workflow
+
+## Decision
+
+The current Remix application uses a fail-closed publication model.
+
+Only content that is publishable for the target build may appear in either of these routable locations:
+
+- the runtime blog metadata registries consumed by `app/content/blog-provider.ts`;
+- a static `app/routes/blog.<slug>/` MDX route directory.
+
+Draft and future content must remain outside both locations. Hiding an entry only from the blog index or sitemap is not sufficient because a direct URL would still exist.
+
+This preserves complete server rendering, JavaScript-disabled access, deterministic Cloudflare builds, and native Remix route splitting without request-time MDX compilation.
+
+## Publication metadata
+
+`app/content/blog-publication.js` is the transitional publication manifest while legacy TSX articles remain. It records the status of every routable registry slug.
+
+The allowed statuses are:
+
+- `published`
+- `draft`
+
+Every entry that remains in a runtime registry must have `published` status and a date on or before the publication cutoff. A draft manifest entry may exist without a runtime route, but a published manifest entry must have matching routable metadata.
+
+The representative MDX article also declares `status: published` in frontmatter. Its static route verifies status and manifest parity before rendering. The build validator owns the target-date cutoff so the server and browser do not independently recompute wall-clock publication state during hydration. As the remaining articles move to MDX, status ownership should move into their canonical frontmatter and the transitional manifest can be generated or removed.
+
+## Publication cutoff
+
+Validation uses the current UTC calendar date by default.
+
+`BLOG_PUBLICATION_DATE=YYYY-MM-DD` may be supplied explicitly to validate a scheduled publication build or preview. Production CI and normal deployment must leave this variable unset unless an intentional dated release is being exercised.
+
+The cutoff is enforced by:
+
+- `scripts/check-blog-content-boundaries.js` before CI and deployment builds;
+- `scripts/generate-sitemap.js` before sitemap generation.
+
+Static MDX route modules enforce published status and manifest parity without consulting the browser clock. This lets an explicitly dated preview hydrate deterministically while the build pipeline remains authoritative for whether the route may exist.
+
+Future-dated content is therefore not silently indexed or deployed. It must stay non-routable until its publication build is intentional.
+
+## Authoring a draft
+
+1. Keep the draft outside `app/routes` and outside the runtime metadata registries.
+2. Use `status: draft` in canonical MDX frontmatter when the draft content pipeline supports it.
+3. Do not add the slug as a published entry in the publication manifest.
+4. Preview through a non-production authoring workflow rather than creating a public route.
+
+## Publishing an article
+
+1. Confirm the article date is on or before the target publication cutoff.
+2. Set canonical MDX frontmatter to `status: published`.
+3. Add or generate the static route and runtime metadata projection.
+4. Add the publication manifest entry while legacy registries remain.
+5. Run:
+
+   ```sh
+   yarn test:unit
+   yarn test:blog-mdx-validation
+   yarn test:blog-content-boundaries
+   node scripts/generate-sitemap.js
+   yarn typecheck
+   yarn build
+   yarn cloudflare:functions:build
+   yarn test:integration
+   yarn test:e2e
+   yarn test:e2e:cloudflare
+   ```
+
+6. Verify the article appears in the index, series navigation, related links, structured data, and sitemap.
+
+## Test layers
+
+- Unit tests exercise date parsing, cutoff behavior, manifest coverage, draft exclusion, future-date rejection, and MDX status rules.
+- Integration tests exercise the direct Cloudflare Pages adapter and the source-isolated workerd artifact, including 404 behavior for unpublished URLs.
+- End-to-end tests exercise published articles, client navigation, JavaScript-disabled rendering, and unpublished-route exclusion in Chromium.
+- The MDX grammar validator rejects unsupported syntax, executable expressions, unsafe component props, invalid local assets, and unknown cross-post targets.
+
+## Follow-up
+
+Issue #55 still needs to migrate the remaining TSX article bodies, make frontmatter the complete metadata authority, and verify browser-chunk isolation across the expanded MDX route set.

--- a/e2e/mdx.spec.ts
+++ b/e2e/mdx.spec.ts
@@ -3,6 +3,11 @@ import { expect, test } from "@playwright/test"
 const articlePath = "/blog/ai-pipelines-need-control-boundaries"
 const legacyArticlePath = "/blog/secure-platform-integration-is-not-plumbing"
 
+const unpublishedArticlePaths = [
+  "/blog/draft-publication-fixture",
+  "/blog/future-publication-fixture",
+]
+
 test.describe("representative MDX article", () => {
   test("renders canonical content, components, metadata, and series navigation", async ({
     page,
@@ -110,6 +115,15 @@ test("legacy TSX articles continue through the dynamic route", async ({
   await expect(page.locator("main")).toContainText(
     "Secure platform integration is not plumbing",
   )
+})
+
+test("draft and future blog URLs remain unavailable", async ({ page }) => {
+  for (const pathname of unpublishedArticlePaths) {
+    const response = await page.goto(pathname)
+
+    expect(response?.status()).toBe(404)
+    await expect(page.getByText("Not Found", { exact: true })).toBeVisible()
+  }
 })
 
 test.describe("representative MDX article without JavaScript", () => {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "start": "remix-serve build/index.js",
+    "test": "run-s test:unit test:blog-mdx-validation test:integration",
     "test:blog-content-boundaries": "node scripts/check-blog-content-boundaries.js",
     "test:blog-mdx-validation": "node scripts/test-blog-mdx-validation.js",
     "test:cloudflare:adapter": "node scripts/test-cloudflare-adapter.js",
@@ -28,8 +29,10 @@
     "test:e2e:cloudflare": "playwright test --config playwright.cloudflare.config.ts",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:mobile": "playwright test --project=mobile-chromium",
+    "test:integration": "run-s test:cloudflare:adapter test:cloudflare:runtime",
+    "test:unit": "node --test --experimental-test-coverage --test-coverage-lines=95 --test-coverage-functions=100 --test-coverage-branches=90 tests/unit/*.test.js",
     "typecheck": "tsc -b",
-    "deploy:cloudflare": "yarn test:blog-mdx-validation && yarn test:blog-content-boundaries && yarn typecheck && yarn build && yarn cloudflare:functions:build && yarn test:cloudflare:bundle-budget && yarn test:cloudflare:adapter && yarn test:cloudflare:runtime && wrangler pages deploy public --project-name ${CLOUDFLARE_PAGES_PROJECT:-micrantha-web} --branch ${CLOUDFLARE_PAGES_BRANCH:-main} --upload-source-maps"
+    "deploy:cloudflare": "yarn test:unit && yarn test:blog-mdx-validation && yarn test:blog-content-boundaries && yarn typecheck && yarn build && yarn cloudflare:functions:build && yarn test:cloudflare:bundle-budget && yarn test:integration && wrangler pages deploy public --project-name ${CLOUDFLARE_PAGES_PROJECT:-micrantha-web} --branch ${CLOUDFLARE_PAGES_BRANCH:-main} --upload-source-maps"
   },
   "dependencies": {
     "@remix-run/node": "2.17.4",

--- a/scripts/check-blog-content-boundaries.js
+++ b/scripts/check-blog-content-boundaries.js
@@ -3,6 +3,11 @@ import { readdir, readFile, stat } from "node:fs/promises"
 import path from "node:path"
 
 import {
+  assertRoutableBlogPublication,
+  assertRoutableMdxPublication,
+  resolvePublicationCutoff,
+} from "../app/content/blog-publication.js"
+import {
   assertBlogPostContentOptional,
   buildSitemapXml,
   loadBlogContentInventory,
@@ -12,6 +17,9 @@ import { validateBlogMdxFile } from "./blog-mdx-validation.js"
 
 const routesDirectory = path.join(repositoryRoot, "app/routes")
 const sitemapPath = path.join(repositoryRoot, "public/sitemap.xml")
+const publicationCutoff = resolvePublicationCutoff(
+  process.env.BLOG_PUBLICATION_DATE,
+)
 
 async function pathExists(filePath) {
   try {
@@ -21,6 +29,22 @@ async function pathExists(filePath) {
     if (error?.code === "ENOENT") return false
     throw error
   }
+}
+
+function readFrontmatterField(frontmatter, name, routeName) {
+  const line = frontmatter
+    .split("\n")
+    .find((candidate) => candidate.startsWith(`${name}:`))
+
+  assert.ok(line, `MDX route ${routeName} is missing ${name} frontmatter`)
+
+  const value = line
+    .slice(name.length + 1)
+    .trim()
+    .replace(/^(["'])|(["'])$/g, "")
+  assert.notEqual(value, "", `MDX route ${routeName} has empty ${name}`)
+
+  return value
 }
 
 async function discoverMdxRoutes() {
@@ -42,9 +66,25 @@ async function discoverMdxRoutes() {
       `MDX route ${entry.name} is missing route.tsx`,
     )
 
+    const source = await readFile(contentPath, "utf8")
+    const frontmatter = source.match(/^---\n([\s\S]*?)\n---(?:\n|$)/)?.[1]
+
+    assert.ok(frontmatter, `MDX route ${entry.name} is missing frontmatter`)
+
+    const slug = entry.name.slice("blog.".length)
+    const declaredSlug = readFrontmatterField(frontmatter, "slug", entry.name)
+
+    assert.equal(
+      declaredSlug,
+      slug,
+      `MDX route ${entry.name} frontmatter slug must match its route`,
+    )
+
     routes.push({
       relativePath: path.relative(repositoryRoot, contentPath),
-      slug: entry.name.slice("blog.".length),
+      slug,
+      date: readFrontmatterField(frontmatter, "date", entry.name),
+      status: readFrontmatterField(frontmatter, "status", entry.name),
     })
   }
 
@@ -65,22 +105,28 @@ const [mdxRoutes, inventory, currentSitemap] = await Promise.all([
   readFile(sitemapPath, "utf8"),
 ])
 
+assertRoutableBlogPublication(inventory.posts, {
+  cutoff: publicationCutoff,
+})
+
 await Promise.all(
   mdxRoutes.map((route) => validateBlogMdxFile(route.relativePath, inventory)),
 )
 
-const mdxSlugs = mdxRoutes.map((route) => route.slug)
+for (const route of mdxRoutes) {
+  assertRoutableMdxPublication(route, { cutoff: publicationCutoff })
 
-for (const slug of mdxSlugs) {
-  const post = inventory.postsBySlug.get(slug)
+  const post = inventory.postsBySlug.get(route.slug)
 
-  assert.ok(post, `MDX route ${slug} is missing registry metadata`)
+  assert.ok(post, `MDX route ${route.slug} is missing registry metadata`)
   assert.equal(
     post.hasContent,
     false,
-    `MDX route ${slug} still has a legacy Content renderer in ${post.source}`,
+    `MDX route ${route.slug} still has a legacy Content renderer in ${post.source}`,
   )
 }
+
+const mdxSlugs = mdxRoutes.map((route) => route.slug)
 
 for (const post of inventory.posts) {
   if (mdxSlugs.includes(post.slug)) continue
@@ -101,7 +147,7 @@ assert.equal(
 )
 
 console.log(
-  `Blog content boundaries passed: ${inventory.posts.length} post(s), ${inventory.series.length} series, ${mdxSlugs.length} MDX route(s), ${
+  `Blog content boundaries passed at ${publicationCutoff}: ${inventory.posts.length} published post(s), ${inventory.series.length} series, ${mdxSlugs.length} MDX route(s), ${
     inventory.posts.length - mdxSlugs.length
   } legacy TSX route(s), MDX grammar enforced, sitemap current`,
 )

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -2,16 +2,27 @@ import { writeFile } from "node:fs/promises"
 import path from "node:path"
 
 import {
+  assertRoutableBlogPublication,
+  resolvePublicationCutoff,
+} from "../app/content/blog-publication.js"
+import {
   buildSitemapXml,
   loadBlogContentInventory,
   repositoryRoot,
 } from "./blog-content-inventory.js"
 
 const inventory = await loadBlogContentInventory()
+const publicationCutoff = resolvePublicationCutoff(
+  process.env.BLOG_PUBLICATION_DATE,
+)
 const sitemapPath = path.join(repositoryRoot, "public/sitemap.xml")
+
+assertRoutableBlogPublication(inventory.posts, {
+  cutoff: publicationCutoff,
+})
 
 await writeFile(sitemapPath, buildSitemapXml(inventory))
 
 console.log(
-  `Generated sitemap for ${inventory.posts.length} post(s) and ${inventory.series.length} series`,
+  `Generated sitemap at ${publicationCutoff} for ${inventory.posts.length} published post(s) and ${inventory.series.length} series`,
 )

--- a/scripts/test-cloudflare-adapter.js
+++ b/scripts/test-cloudflare-adapter.js
@@ -104,6 +104,19 @@ assert.equal(botArticle.response.status, 200)
 assert.match(botArticle.body, /AI Pipelines Need Control Boundaries/)
 assertDocumentHeaders(botArticle.response, botArticle.body)
 
+for (const pathname of [
+  "/blog/draft-publication-fixture",
+  "/blog/future-publication-fixture",
+]) {
+  const unpublished = await read(pathname)
+
+  assert.equal(unpublished.response.status, 404)
+  assert.match(unpublished.body, /404|Not Found/i)
+  assertDocumentHeaders(unpublished.response, unpublished.body, {
+    requireNonce: false,
+  })
+}
+
 const methodNotAllowed = await read("/services", { method: "POST" })
 assert.equal(methodNotAllowed.response.status, 405)
 assert.match(methodNotAllowed.body, /405|Method Not Allowed/i)

--- a/tests/unit/blog-publication.test.js
+++ b/tests/unit/blog-publication.test.js
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  assertRoutableBlogPublication,
+  assertRoutableMdxPublication,
+  filterPublishedBlogPosts,
+  getBlogPublicationStatus,
+  isCalendarDate,
+  isPublishedBlogPost,
+  resolvePublicationCutoff,
+} from "../../app/content/blog-publication.js"
+
+const publishedPost = {
+  slug: "published-post",
+  date: "2026-08-03",
+}
+
+const manifest = {
+  "published-post": { status: "published" },
+  "draft-post": { status: "draft" },
+}
+
+test("validates strict calendar dates", () => {
+  assert.equal(isCalendarDate("2026-08-03"), true)
+  assert.equal(isCalendarDate("2026-02-29"), false)
+  assert.equal(isCalendarDate("2026-8-3"), false)
+  assert.equal(isCalendarDate(null), false)
+})
+
+test("resolves explicit and current UTC publication cutoffs", () => {
+  assert.equal(resolvePublicationCutoff("2026-08-03"), "2026-08-03")
+  assert.equal(
+    resolvePublicationCutoff(undefined, new Date("2026-08-04T23:59:59Z")),
+    "2026-08-04",
+  )
+  assert.throws(
+    () => resolvePublicationCutoff("2026-02-29"),
+    /valid YYYY-MM-DD/,
+  )
+})
+
+test("filters publication metadata without exposing drafts", () => {
+  const posts = [publishedPost, { slug: "draft-post", date: "2026-08-03" }]
+
+  assert.equal(
+    getBlogPublicationStatus("published-post", manifest),
+    "published",
+  )
+  assert.equal(getBlogPublicationStatus("missing-post", manifest), null)
+  assert.equal(isPublishedBlogPost(publishedPost, manifest), true)
+  assert.equal(isPublishedBlogPost(posts[1], manifest), false)
+  assert.deepEqual(filterPublishedBlogPosts(posts, manifest), [publishedPost])
+})
+
+test("accepts published routable metadata at the cutoff", () => {
+  assert.deepEqual(
+    assertRoutableBlogPublication([publishedPost], {
+      manifest: { "published-post": { status: "published" } },
+      cutoff: "2026-08-03",
+    }),
+    [publishedPost],
+  )
+})
+
+test("rejects missing, draft, future, duplicate, and stale publication metadata", () => {
+  assert.throws(
+    () =>
+      assertRoutableBlogPublication([publishedPost], {
+        manifest: {},
+        cutoff: "2026-08-03",
+      }),
+    /missing publication metadata/,
+  )
+  assert.throws(
+    () =>
+      assertRoutableBlogPublication([publishedPost], {
+        manifest: { "published-post": { status: "draft" } },
+        cutoff: "2026-08-03",
+      }),
+    /draft but remains routable/,
+  )
+  assert.throws(
+    () =>
+      assertRoutableBlogPublication(
+        [{ ...publishedPost, date: "2026-08-04" }],
+        {
+          manifest: { "published-post": { status: "published" } },
+          cutoff: "2026-08-03",
+        },
+      ),
+    /after publication cutoff/,
+  )
+  assert.throws(
+    () =>
+      assertRoutableBlogPublication([publishedPost, publishedPost], {
+        manifest: { "published-post": { status: "published" } },
+        cutoff: "2026-08-03",
+      }),
+    /Duplicate routable blog slug/,
+  )
+  assert.throws(
+    () =>
+      assertRoutableBlogPublication([publishedPost], {
+        manifest: {
+          "published-post": { status: "published" },
+          "stale-post": { status: "published" },
+        },
+        cutoff: "2026-08-03",
+      }),
+    /missing routable metadata/,
+  )
+})
+
+test("rejects malformed records and unsupported statuses", () => {
+  assert.throws(
+    () =>
+      assertRoutableBlogPublication([{ slug: "", date: "2026-08-03" }], {
+        manifest: {},
+        cutoff: "2026-08-03",
+      }),
+    /non-empty slug/,
+  )
+  assert.throws(
+    () =>
+      assertRoutableBlogPublication(
+        [{ slug: "published-post", date: "August 3" }],
+        {
+          manifest: { "published-post": { status: "published" } },
+          cutoff: "2026-08-03",
+        },
+      ),
+    /valid YYYY-MM-DD date/,
+  )
+  assert.throws(
+    () =>
+      assertRoutableBlogPublication([publishedPost], {
+        manifest: { "published-post": { status: "scheduled" } },
+        cutoff: "2026-08-03",
+      }),
+    /unsupported publication status/,
+  )
+})
+
+test("allows non-routable draft manifest entries", () => {
+  assert.doesNotThrow(() =>
+    assertRoutableBlogPublication([publishedPost], {
+      manifest,
+      cutoff: "2026-08-03",
+    }),
+  )
+})
+
+test("enforces published MDX frontmatter and manifest parity", () => {
+  const mdxPost = { ...publishedPost, status: "published" }
+
+  assert.deepEqual(
+    assertRoutableMdxPublication(mdxPost, {
+      manifest: { "published-post": { status: "published" } },
+      cutoff: "2026-08-03",
+    }),
+    mdxPost,
+  )
+  assert.throws(
+    () =>
+      assertRoutableMdxPublication(
+        { ...mdxPost, status: "draft" },
+        {
+          manifest: { "published-post": { status: "published" } },
+          cutoff: "2026-08-03",
+        },
+      ),
+    /must declare status published/,
+  )
+  assert.throws(
+    () =>
+      assertRoutableMdxPublication(mdxPost, {
+        manifest: { "published-post": { status: "draft" } },
+        cutoff: "2026-08-03",
+      }),
+    /draft but remains routable/,
+  )
+})


### PR DESCRIPTION
## Summary

- add a transitional publication manifest for the six current blog posts
- filter runtime blog metadata through published status
- require static MDX routes to declare `status: published`
- reject routable draft or future-dated content before CI builds, sitemap generation, and Cloudflare deployment
- support an explicit `BLOG_PUBLICATION_DATE=YYYY-MM-DD` preview cutoff while production defaults to the current UTC date
- document the draft and publication workflow for native static MDX routes
- preserve and compose with the approved MDX grammar validator already on `main`

## Test pyramid

### Unit

- strict calendar-date parsing
- publication cutoff resolution
- draft filtering
- missing and unsupported status rejection
- future-date rejection
- duplicate and stale manifest detection
- static MDX status and manifest parity
- enforced line/function/branch coverage thresholds

### Integration

- approved MDX grammar and component-prop validation
- direct Cloudflare Pages adapter contract
- source-isolated asset-first workerd runtime contract
- draft/future placeholder URLs remain 404 through the production adapter

### End-to-end

- published MDX and legacy TSX routes remain available
- hydrated client navigation remains functional
- JavaScript-disabled MDX content remains complete
- draft/future placeholder URLs remain unavailable in desktop and mobile Chromium

## Publication model

The current native-route architecture fails closed. Draft and future content must remain outside `app/routes` and outside runtime metadata registries. CI and deployment reject any routable record that is not published by the target cutoff, preventing direct URL, index, series, and sitemap leakage.

The build validator owns the target-date cutoff. Static route modules validate status and manifest parity without independently consulting the browser clock, keeping scheduled previews deterministic across SSR and hydration.

This is transitional while five legacy TSX articles remain. As they move to MDX, canonical frontmatter should replace the manifest as the complete metadata authority.

## Validation

CI run `30877901876` passed both required jobs on head `95012d6eb1986e2b6b49fb09e5cf04d4823b4390`, based on `main` commit `8dcbb1c19ab81b7291e2c49be4c37bbb7decf19f`.

### Quality — passed

- publication unit tests with enforced coverage thresholds
- repository formatting and lint
- approved MDX grammar validator tests
- combined publication, route, registry, series, and sitemap boundaries
- TypeScript and production Remix builds
- pinned Wrangler and Worker bundle budget
- direct Pages adapter and source-isolated workerd integration contracts

### End-to-end — passed

- complete desktop/mobile functional Playwright suite
- published MDX and legacy TSX route behavior
- draft/future placeholder route exclusion
- hydrated client navigation
- JavaScript-disabled article rendering
- staged workerd hydration and browser-error contracts
- no failure artifacts

Progresses #55.