### PR TITLE
Keep draft and future blog posts outside production routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Test blog MDX grammar validator
         run: yarn test:blog-mdx-validation
 
+      - name: Test blog publication boundary
+        run: yarn test:blog-mdx-publication
+
       - name: Validate blog content boundaries
         run: yarn test:blog-content-boundaries
 

--- a/app/routes/blog.ai-pipelines-need-control-boundaries/content.mdx
+++ b/app/routes/blog.ai-pipelines-need-control-boundaries/content.mdx
@@ -1,5 +1,6 @@
 ---
 slug: ai-pipelines-need-control-boundaries
+status: published
 title: AI Pipelines Need Control Boundaries
 description: Enterprise AI should be treated as an untrusted reasoning component inside a governed integration path.
 date: "2026-04-24"

--- a/app/routes/blog.ai-pipelines-need-control-boundaries/route.tsx
+++ b/app/routes/blog.ai-pipelines-need-control-boundaries/route.tsx
@@ -1,4 +1,5 @@
 import type { MetaFunction } from "@remix-run/node"
+import { json } from "@remix-run/node"
 
 import { BlogArticleLayout } from "~/components/blog-article-layout"
 import { blogMdxComponents } from "~/components/blog-mdx-components"
@@ -66,13 +67,23 @@ function requiredSeries() {
 }
 
 const slug = requiredString("slug")
+const status = requiredString("status")
 const date = requiredString("date")
+const parsedDate = new Date(`${date}T00:00:00Z`)
 
 if (slug !== EXPECTED_SLUG) {
   throw new Error(`MDX slug ${slug} does not match route ${EXPECTED_SLUG}`)
 }
 
-if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || Number.isNaN(Date.parse(date))) {
+if (!new Set(["draft", "published"]).has(status)) {
+  throw new Error(`Invalid MDX publication status: ${status}`)
+}
+
+if (
+  !/^\d{4}-\d{2}-\d{2}$/.test(date) ||
+  Number.isNaN(parsedDate.valueOf()) ||
+  parsedDate.toISOString().slice(0, 10) !== date
+) {
   throw new Error(`Invalid MDX publication date: ${date}`)
 }
 
@@ -105,23 +116,56 @@ for (const field of ["tags", "relatedSlugs", "series"] as const) {
   }
 }
 
-export const meta: MetaFunction = () =>
-  buildArticleMeta({
+type LoaderData = {
+  publication: {
+    date: string
+    status: string
+  }
+}
+
+export async function loader() {
+  const publicationDate = new Date().toISOString().slice(0, 10)
+
+  if (status !== "published" || date > publicationDate) {
+    throw new Response("Not Found", { status: 404 })
+  }
+
+  return json<LoaderData>({
+    publication: {
+      date,
+      status,
+    },
+  })
+}
+
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  if (!data) {
+    return [
+      { title: "Micrantha Software | Blog" },
+      { name: "robots", content: "noindex" },
+    ]
+  }
+
+  return buildArticleMeta({
     title: post.title,
     description: post.description,
     path: `/blog/${post.slug}`,
     publishedTime: `${post.date}T00:00:00Z`,
     tags: post.tags,
   })
+}
 
 export const handle = {
-  structuredData: buildArticleStructuredData({
-    title: post.title,
-    description: post.description,
-    path: `/blog/${post.slug}`,
-    datePublished: `${post.date}T00:00:00Z`,
-    keywords: post.tags,
-  }),
+  structuredData: (data: LoaderData | undefined) =>
+    data
+      ? buildArticleStructuredData({
+          title: post.title,
+          description: post.description,
+          path: `/blog/${post.slug}`,
+          datePublished: `${post.date}T00:00:00Z`,
+          keywords: post.tags,
+        })
+      : null,
 }
 
 export default function AiPipelinesNeedControlBoundariesRoute() {

--- a/docs/blog-publication.md
+++ b/docs/blog-publication.md
@@ -1,0 +1,49 @@
+# Blog publication workflow
+
+Blog publication is structural. Content is not hidden at runtime after being added to the public route graph; unpublished content stays outside that graph.
+
+## Publication states
+
+Every MDX article declares one of two frontmatter states:
+
+- `draft`: work that is not available from the production application.
+- `published`: content eligible for production once its `date` is today or earlier in UTC.
+
+A `published` article with a future date is scheduled content. It remains structurally unpublished until its date arrives.
+
+## Draft and scheduled content
+
+Drafts and future-dated articles must remain outside `app/routes` and outside the published blog registries. A suitable private branch or a non-route working directory may hold work in progress, but production code must not import it.
+
+Do not create any of these until publication:
+
+- `app/routes/blog.<slug>/route.tsx`
+- `app/routes/blog.<slug>/content.mdx`
+- a published registry entry
+- related-post references from published posts
+- sitemap or series membership
+
+Because the slug is absent from both the route graph and the published registry, a direct production request returns `404` through the existing dynamic blog route.
+
+## Publishing an article
+
+1. Set frontmatter `status` to `published`.
+2. Confirm `date` is a valid `YYYY-MM-DD` calendar date and is today or earlier in UTC.
+3. Create the static route folder `app/routes/blog.<slug>/`.
+4. Add `content.mdx` and its route wrapper.
+5. Add matching metadata to the published registry without a legacy TSX renderer.
+6. Add only known related slugs and a valid series membership, if applicable.
+7. Regenerate the sitemap when metadata changes.
+8. Run `yarn test:blog-mdx-validation`, `yarn test:blog-mdx-publication`, and `yarn test:blog-content-boundaries`.
+
+Required CI and `deploy:cloudflare` repeat these checks. A routable draft, a future-dated route, a future-dated published registry entry, malformed YAML, or an invalid calendar date blocks deployment.
+
+## Production and preview behavior
+
+Production has no unpublished-content override. Draft and scheduled routes are not deployed, and production requests for their slugs return `404`.
+
+Local review should use a private branch and temporary local route changes. Those changes must not be merged while the article is draft or future-dated. The publication checks intentionally fail closed if such a route reaches CI.
+
+## Time boundary
+
+Publication eligibility uses the current UTC calendar date. Date-only metadata therefore has one stable interpretation across developer machines, GitHub Actions, and Cloudflare builds.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint:fix": "eslint --fix .",
     "start": "remix-serve build/index.js",
     "test:blog-content-boundaries": "node scripts/check-blog-content-boundaries.js",
+    "test:blog-mdx-publication": "node scripts/test-blog-mdx-publication.js",
     "test:blog-mdx-validation": "node scripts/test-blog-mdx-validation.js",
     "test:cloudflare:adapter": "node scripts/test-cloudflare-adapter.js",
     "test:cloudflare:bundle-budget": "node scripts/check-cloudflare-bundle-budget.js",
@@ -29,7 +30,7 @@
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:mobile": "playwright test --project=mobile-chromium",
     "typecheck": "tsc -b",
-    "deploy:cloudflare": "yarn test:blog-mdx-validation && yarn test:blog-content-boundaries && yarn typecheck && yarn build && yarn cloudflare:functions:build && yarn test:cloudflare:bundle-budget && yarn test:cloudflare:adapter && yarn test:cloudflare:runtime && wrangler pages deploy public --project-name ${CLOUDFLARE_PAGES_PROJECT:-micrantha-web} --branch ${CLOUDFLARE_PAGES_BRANCH:-main} --upload-source-maps"
+    "deploy:cloudflare": "yarn test:blog-mdx-validation && yarn test:blog-mdx-publication && yarn test:blog-content-boundaries && yarn typecheck && yarn build && yarn cloudflare:functions:build && yarn test:cloudflare:bundle-budget && yarn test:cloudflare:adapter && yarn test:cloudflare:runtime && wrangler pages deploy public --project-name ${CLOUDFLARE_PAGES_PROJECT:-micrantha-web} --branch ${CLOUDFLARE_PAGES_BRANCH:-main} --upload-source-maps"
   },
   "dependencies": {
     "@remix-run/node": "2.17.4",
@@ -62,7 +63,8 @@
     "tailwindcss": "4.2.2",
     "typescript": "^5.1.6",
     "typescript-eslint": "8.57.1",
-    "wrangler": "4.114.0"
+    "wrangler": "4.114.0",
+    "yaml": "^2.3.4"
   },
   "engines": {
     "node": ">=18"

--- a/scripts/blog-mdx-publication.js
+++ b/scripts/blog-mdx-publication.js
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict"
+
+import { parseDocument } from "yaml"
+
+export const blogPublicationStatuses = new Set(["draft", "published"])
+
+function extractFrontmatter(source, relativePath) {
+  const normalized = source.replaceAll("\r\n", "\n")
+
+  assert.ok(
+    normalized.startsWith("---\n"),
+    `${relativePath} must begin with YAML frontmatter`,
+  )
+
+  const closingDelimiter = normalized.indexOf("\n---\n", 4)
+
+  assert.notEqual(
+    closingDelimiter,
+    -1,
+    `${relativePath} is missing its closing frontmatter delimiter`,
+  )
+
+  return normalized.slice(4, closingDelimiter)
+}
+
+export function validateBlogPublicationDate(value, context) {
+  assert.equal(typeof value, "string", `${context} must be a string`)
+  assert.match(value, /^\d{4}-\d{2}-\d{2}$/u, `${context} must be YYYY-MM-DD`)
+
+  const parsed = new Date(`${value}T00:00:00Z`)
+
+  assert.equal(
+    Number.isNaN(parsed.valueOf()),
+    false,
+    `${context} must be a valid calendar date`,
+  )
+  assert.equal(
+    parsed.toISOString().slice(0, 10),
+    value,
+    `${context} must be a valid calendar date`,
+  )
+
+  return value
+}
+
+export function currentBlogPublicationDate(now = new Date()) {
+  assert.ok(now instanceof Date, "Publication clock must be a Date")
+  assert.equal(
+    Number.isNaN(now.valueOf()),
+    false,
+    "Publication clock must be valid",
+  )
+
+  return now.toISOString().slice(0, 10)
+}
+
+export function parseBlogMdxPublication(source, relativePath) {
+  const document = parseDocument(extractFrontmatter(source, relativePath), {
+    strict: true,
+    uniqueKeys: true,
+  })
+
+  assert.equal(
+    document.errors.length,
+    0,
+    `${relativePath} has invalid YAML frontmatter: ${document.errors
+      .map((error) => error.message)
+      .join("; ")}`,
+  )
+
+  const frontmatter = document.toJS({ maxAliasCount: 0 })
+
+  assert.ok(
+    frontmatter &&
+      typeof frontmatter === "object" &&
+      !Array.isArray(frontmatter),
+    `${relativePath} frontmatter must be a mapping`,
+  )
+
+  const status = frontmatter.status
+
+  assert.equal(
+    typeof status,
+    "string",
+    `${relativePath} frontmatter.status must be a string`,
+  )
+  assert.ok(
+    blogPublicationStatuses.has(status),
+    `${relativePath} frontmatter.status must be draft or published`,
+  )
+
+  return {
+    status,
+    date: validateBlogPublicationDate(
+      frontmatter.date,
+      `${relativePath} frontmatter.date`,
+    ),
+  }
+}
+
+export function isBlogPublicationAvailable(publication, asOfDate) {
+  const cutoff = validateBlogPublicationDate(asOfDate, "Publication cutoff")
+
+  return publication.status === "published" && publication.date <= cutoff
+}
+
+export function assertRoutableBlogMdxPublished({
+  asOfDate = currentBlogPublicationDate(),
+  relativePath,
+  source,
+}) {
+  const publication = parseBlogMdxPublication(source, relativePath)
+
+  assert.equal(
+    publication.status,
+    "published",
+    `${relativePath} is routable but has status ${publication.status}; drafts must remain outside app/routes`,
+  )
+  assert.equal(
+    publication.date <=
+      validateBlogPublicationDate(asOfDate, "Publication cutoff"),
+    true,
+    `${relativePath} is routable before publication date ${publication.date}; future posts must remain outside app/routes`,
+  )
+
+  return publication
+}
+
+export function assertPublishedRegistryPost(post, asOfDate) {
+  const cutoff = validateBlogPublicationDate(asOfDate, "Publication cutoff")
+  const date = validateBlogPublicationDate(
+    post.date,
+    `Registry post ${post.slug} date`,
+  )
+
+  assert.equal(
+    date <= cutoff,
+    true,
+    `Registry post ${post.slug} is future-dated (${date}); unpublished posts must remain outside the published registry`,
+  )
+}

--- a/scripts/check-blog-content-boundaries.js
+++ b/scripts/check-blog-content-boundaries.js
@@ -9,6 +9,11 @@ import {
   repositoryRoot,
 } from "./blog-content-inventory.js"
 import { validateBlogMdxFile } from "./blog-mdx-validation.js"
+import {
+  assertPublishedRegistryPost,
+  assertRoutableBlogMdxPublished,
+  currentBlogPublicationDate,
+} from "./blog-mdx-publication.js"
 
 const routesDirectory = path.join(repositoryRoot, "app/routes")
 const sitemapPath = path.join(repositoryRoot, "public/sitemap.xml")
@@ -64,12 +69,30 @@ const [mdxRoutes, inventory, currentSitemap] = await Promise.all([
   loadBlogContentInventory(),
   readFile(sitemapPath, "utf8"),
 ])
+const publicationDate = currentBlogPublicationDate()
 
 await Promise.all(
-  mdxRoutes.map((route) => validateBlogMdxFile(route.relativePath, inventory)),
+  mdxRoutes.map(async (route) => {
+    await validateBlogMdxFile(route.relativePath, inventory)
+
+    const source = await readFile(
+      path.join(repositoryRoot, route.relativePath),
+      "utf8",
+    )
+
+    assertRoutableBlogMdxPublished({
+      asOfDate: publicationDate,
+      relativePath: route.relativePath,
+      source,
+    })
+  }),
 )
 
 const mdxSlugs = mdxRoutes.map((route) => route.slug)
+
+for (const post of inventory.posts) {
+  assertPublishedRegistryPost(post, publicationDate)
+}
 
 for (const slug of mdxSlugs) {
   const post = inventory.postsBySlug.get(slug)
@@ -101,7 +124,7 @@ assert.equal(
 )
 
 console.log(
-  `Blog content boundaries passed: ${inventory.posts.length} post(s), ${inventory.series.length} series, ${mdxSlugs.length} MDX route(s), ${
+  `Blog content boundaries passed for ${publicationDate}: ${inventory.posts.length} published post(s), ${inventory.series.length} series, ${mdxSlugs.length} MDX route(s), ${
     inventory.posts.length - mdxSlugs.length
-  } legacy TSX route(s), MDX grammar enforced, sitemap current`,
+  } legacy TSX route(s), MDX grammar and publication boundaries enforced, sitemap current`,
 )

--- a/scripts/test-blog-mdx-publication.js
+++ b/scripts/test-blog-mdx-publication.js
@@ -29,14 +29,8 @@ assert.deepEqual(published, {
   status: "published",
   date: "2026-08-03",
 })
-assert.equal(
-  isBlogPublicationAvailable(published, "2026-08-03"),
-  true,
-)
-assert.equal(
-  isBlogPublicationAvailable(published, "2026-08-02"),
-  false,
-)
+assert.equal(isBlogPublicationAvailable(published, "2026-08-03"), true)
+assert.equal(isBlogPublicationAvailable(published, "2026-08-02"), false)
 assert.equal(
   isBlogPublicationAvailable(
     parseBlogMdxPublication(source("draft", "2026-08-03"), relativePath),
@@ -73,11 +67,13 @@ assert.throws(
   /future posts must remain outside app\/routes/u,
 )
 assert.throws(
-  () => parseBlogMdxPublication(source("scheduled", "2026-08-03"), relativePath),
+  () =>
+    parseBlogMdxPublication(source("scheduled", "2026-08-03"), relativePath),
   /must be draft or published/u,
 )
 assert.throws(
-  () => parseBlogMdxPublication(source("published", "2026-02-30"), relativePath),
+  () =>
+    parseBlogMdxPublication(source("published", "2026-02-30"), relativePath),
   /valid calendar date/u,
 )
 assert.throws(

--- a/scripts/test-blog-mdx-publication.js
+++ b/scripts/test-blog-mdx-publication.js
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict"
+
+import {
+  assertPublishedRegistryPost,
+  assertRoutableBlogMdxPublished,
+  currentBlogPublicationDate,
+  isBlogPublicationAvailable,
+  parseBlogMdxPublication,
+} from "./blog-mdx-publication.js"
+
+const relativePath = "app/routes/blog.publication-contract/content.mdx"
+
+function source(status, date) {
+  return `---
+status: ${status}
+date: "${date}"
+---
+
+Publication contract fixture.
+`
+}
+
+const published = parseBlogMdxPublication(
+  source("published", "2026-08-03"),
+  relativePath,
+)
+
+assert.deepEqual(published, {
+  status: "published",
+  date: "2026-08-03",
+})
+assert.equal(
+  isBlogPublicationAvailable(published, "2026-08-03"),
+  true,
+)
+assert.equal(
+  isBlogPublicationAvailable(published, "2026-08-02"),
+  false,
+)
+assert.equal(
+  isBlogPublicationAvailable(
+    parseBlogMdxPublication(source("draft", "2026-08-03"), relativePath),
+    "2026-08-03",
+  ),
+  false,
+)
+
+assert.deepEqual(
+  assertRoutableBlogMdxPublished({
+    asOfDate: "2026-08-03",
+    relativePath,
+    source: source("published", "2026-08-03"),
+  }),
+  published,
+)
+
+assert.throws(
+  () =>
+    assertRoutableBlogMdxPublished({
+      asOfDate: "2026-08-03",
+      relativePath,
+      source: source("draft", "2026-08-03"),
+    }),
+  /drafts must remain outside app\/routes/u,
+)
+assert.throws(
+  () =>
+    assertRoutableBlogMdxPublished({
+      asOfDate: "2026-08-03",
+      relativePath,
+      source: source("published", "2026-08-04"),
+    }),
+  /future posts must remain outside app\/routes/u,
+)
+assert.throws(
+  () => parseBlogMdxPublication(source("scheduled", "2026-08-03"), relativePath),
+  /must be draft or published/u,
+)
+assert.throws(
+  () => parseBlogMdxPublication(source("published", "2026-02-30"), relativePath),
+  /valid calendar date/u,
+)
+assert.throws(
+  () =>
+    parseBlogMdxPublication(
+      `---
+date: "2026-08-03"
+---
+`,
+      relativePath,
+    ),
+  /frontmatter.status must be a string/u,
+)
+
+assert.doesNotThrow(() =>
+  assertPublishedRegistryPost(
+    { slug: "published-post", date: "2026-08-03" },
+    "2026-08-03",
+  ),
+)
+assert.throws(
+  () =>
+    assertPublishedRegistryPost(
+      { slug: "future-post", date: "2026-08-04" },
+      "2026-08-03",
+    ),
+  /must remain outside the published registry/u,
+)
+
+assert.equal(
+  currentBlogPublicationDate(new Date("2026-08-03T23:59:59Z")),
+  "2026-08-03",
+)
+
+console.log(
+  "Blog publication policy tests passed: published, draft, future, invalid status/date, registry, and UTC clock contracts",
+)

--- a/scripts/test-cloudflare-adapter.js
+++ b/scripts/test-cloudflare-adapter.js
@@ -97,6 +97,13 @@ assert.match(
 )
 assertDocumentHeaders(article.response, article.body)
 
+const unpublishedArticle = await read("/blog/publication-contract")
+assert.equal(unpublishedArticle.response.status, 404)
+assert.match(unpublishedArticle.body, /404|Not Found/i)
+assertDocumentHeaders(unpublishedArticle.response, unpublishedArticle.body, {
+  requireNonce: false,
+})
+
 const botArticle = await read("/blog/ai-pipelines-need-control-boundaries", {
   userAgent: "Googlebot/2.1",
 })


### PR DESCRIPTION
## Summary

- define `draft` and `published` MDX frontmatter states
- treat future-dated `published` content as scheduled but unavailable
- parse publication frontmatter with strict YAML and validate real calendar dates
- reject routable draft or future MDX during the required content-boundary check
- reject future-dated entries in the published legacy registry
- add `status: published` to the current canonical MDX article
- add a loader-level 404 defense and suppress article metadata/structured data when unavailable
- verify an unpublished blog slug returns 404 through the production Cloudflare adapter
- run publication fixtures in required CI and before deployment
- document the structural publication workflow and UTC date boundary

## Publication model

Unpublished content stays outside `app/routes` and outside the published registry. Production has no unpublished-content override. Publication requires moving the article into its static route only after `status: published` and its UTC date is current or past.

This makes draft/future exclusion structural: no index, series, related-post, sitemap, or production route can reference unpublished content. The generic legacy route returns 404 for absent slugs, and each native MDX route also defends its own status/date at loader time.

## Validation intent

Required CI covers:

- strict YAML and calendar-date parsing
- published, draft, scheduled, invalid-status, invalid-date, registry, and UTC clock fixtures
- the current routable MDX article and all published registry dates
- unpublished slug 404 through the production adapter
- existing grammar, metadata, sitemap, typecheck, Remix build, Worker budget, workerd, browser, hydration, and JavaScript-disabled contracts

Progresses #55; does not close it.