### PR TITLE
Validate explicit blog publication cutoffs

### DIFF
--- a/app/content/blog-publication.js
+++ b/app/content/blog-publication.js
@@ -105,6 +105,7 @@ export function assertRoutableBlogPublication(
     cutoff = resolvePublicationCutoff(),
   } = {},
 ) {
+  const validatedCutoff = resolvePublicationCutoff(cutoff)
   const routableSlugs = new Set()
 
   for (const [index, post] of posts.entries()) {
@@ -114,7 +115,7 @@ export function assertRoutableBlogPublication(
       throw new Error(`Duplicate routable blog slug ${post.slug}`)
     }
 
-    assertRoutableRecord(post, manifest, cutoff, context)
+    assertRoutableRecord(post, manifest, validatedCutoff, context)
     routableSlugs.add(post.slug)
   }
 
@@ -138,7 +139,14 @@ export function assertRoutableMdxPublication(
     cutoff = resolvePublicationCutoff(),
   } = {},
 ) {
-  assertRoutableRecord(post, manifest, cutoff, `MDX route ${post?.slug ?? ""}`)
+  const validatedCutoff = resolvePublicationCutoff(cutoff)
+
+  assertRoutableRecord(
+    post,
+    manifest,
+    validatedCutoff,
+    `MDX route ${post?.slug ?? ""}`,
+  )
 
   if (post.status !== "published") {
     throw new Error(`MDX route ${post.slug} must declare status published`)

--- a/tests/unit/blog-publication.test.js
+++ b/tests/unit/blog-publication.test.js
@@ -63,6 +63,17 @@ test("accepts published routable metadata at the cutoff", () => {
   )
 })
 
+test("rejects invalid explicit publication cutoffs", () => {
+  assert.throws(
+    () =>
+      assertRoutableBlogPublication([publishedPost], {
+        manifest: { "published-post": { status: "published" } },
+        cutoff: "2026-02-29",
+      }),
+    /valid YYYY-MM-DD/,
+  )
+})
+
 test("rejects missing, draft, future, duplicate, and stale publication metadata", () => {
   assert.throws(
     () =>


### PR DESCRIPTION
## Summary

- validate caller-supplied publication cutoffs inside both exported routability assertions
- prevent malformed explicit cutoffs from falling through to lexicographic date comparisons
- add a focused unit regression for an invalid non-leap-day cutoff

## Review finding

PR #104 correctly validates `BLOG_PUBLICATION_DATE` before passing it into the publication assertions. The exported assertion functions also accept a direct `cutoff` option for tests and future tooling, but previously trusted that value. A malformed direct value such as `2026-02-29` could therefore bypass calendar validation.

This follow-up resolves the inconsistency by normalizing every assertion cutoff through `resolvePublicationCutoff` before evaluating post dates.

## Validation

Successful required CI run: `30878199816`.

### Quality — passed

- unit tests with enforced line, function, and branch coverage thresholds
- formatting and lint
- approved MDX grammar validator
- publication, metadata, series, renderer, and sitemap boundaries
- TypeScript and production Remix builds
- pinned Wrangler and Worker bundle budget
- direct Pages adapter and source-isolated workerd integration contracts

### End-to-end — passed

- complete desktop/mobile functional Chromium suite
- Cloudflare workerd hydration and JavaScript-disabled contracts
- no failure artifacts

## Scope

Small hardening follow-up to #104. No route, manifest, sitemap, grammar, or runtime behavior changes for valid cutoffs.