### PR TITLE
Complete the architecture control boundaries MDX series

### DIFF
--- a/app/content/blog.tsx
+++ b/app/content/blog.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from "react"
-import { Link } from "@remix-run/react"
 
 export type BlogSeriesMembership = {
   slug: string
@@ -20,174 +19,6 @@ export type BlogPost = {
 export const BLOG_TITLE = "Architecture Notes"
 export const BLOG_DESCRIPTION =
   "Architecture notes on secure platform integration, delivery governance, AI-assisted systems, and long-lived software design."
-
-const PostLink = ({
-  slug,
-  children,
-}: {
-  slug: string
-  children: ReactNode
-}) => <Link to={`/blog/${slug}`}>{children}</Link>
-
-const DiagramFrame = ({
-  title,
-  caption,
-  children,
-}: {
-  title: string
-  caption: string
-  children: ReactNode
-}) => (
-  <figure className="article-diagram">
-    <figcaption className="article-diagram-caption">
-      <span className="article-diagram-title">{title}</span>
-      <span className="article-diagram-note">{caption}</span>
-    </figcaption>
-    {children}
-  </figure>
-)
-
-const softwareLayersRiskBoundariesContent = () => (
-  <>
-    <section className="space-y-4">
-      <h2>Why layers still matter</h2>
-      <p>
-        Layered architecture matters because it is one of the simplest ways to
-        keep risk from collapsing into a single code path. Without layers,
-        interface concerns, business rules, integration behavior, and
-        infrastructure choices drift together until every change becomes a
-        coupled change.
-      </p>
-      <p>
-        The useful question is not whether the layers are academically pure. It
-        is whether they preserve replaceability and make failure easier to
-        localize.
-      </p>
-      <DiagramFrame
-        title="Software layers as risk boundaries"
-        caption="Each layer contains a different kind of change so clients, policy, and vendor concerns do not collapse into one code path."
-      >
-        <img
-          className="article-diagram-image"
-          src="/img/blog/software_layers_diagram.svg"
-          alt="Diagram showing clients flowing into interface and application layers, with the application layer connected to both domain and infrastructure."
-        />
-      </DiagramFrame>
-    </section>
-
-    <section className="space-y-4">
-      <h2>Clients and channels</h2>
-      <p>
-        Mobile apps, browser clients, partner interfaces, background jobs, and
-        operator tools all enter the system from different conditions. Their job
-        is to collect intent and present results. They should not become the
-        place where core workflow rules are defined.
-      </p>
-    </section>
-
-    <section className="space-y-4">
-      <h2>Interface layer</h2>
-      <p>
-        The interface layer translates between external protocols and internal
-        use cases. It handles transport concerns such as request validation,
-        authentication context, response shaping, and correlation identifiers.
-        It should not be the home of domain policy.
-      </p>
-    </section>
-
-    <section className="space-y-4">
-      <h2>Application layer</h2>
-      <p>
-        The application layer coordinates workflows. It decides what needs to
-        happen in what order, which policies apply, and which collaborators need
-        to be invoked. This is where enterprise process shape belongs, including
-        AI-assisted steps, approval gates, and integration sequencing.
-      </p>
-    </section>
-
-    <section className="space-y-4">
-      <h2>Domain layer</h2>
-      <p>
-        The domain layer protects business meaning: state transitions,
-        invariants, eligibility rules, and the definitions that make the system
-        more than a collection of endpoints. It should remain understandable
-        without reference to a UI framework, ERP connector, or model provider.
-      </p>
-    </section>
-
-    <section className="space-y-4">
-      <h2>Infrastructure and adapters</h2>
-      <p>
-        Infrastructure is where databases, queues, vendor SDKs, ERP connectors,
-        mobile platform services, and model providers live. These adapters are
-        necessary, but they should remain replaceable. When they leak upward
-        into policy code, vendor replacement becomes a rewrite instead of an
-        integration task.
-      </p>
-    </section>
-
-    <section className="space-y-4">
-      <h2>Why each layer exists</h2>
-      <ul>
-        <li>
-          Clients and channels isolate user-facing behavior and device-specific
-          constraints.
-        </li>
-        <li>
-          The interface layer protects the system from protocol churn and input
-          ambiguity.
-        </li>
-        <li>
-          The application layer governs workflow sequencing and approvals.
-        </li>
-        <li>
-          The domain layer preserves business rules independent of tools and
-          vendors.
-        </li>
-        <li>
-          Infrastructure and adapters keep external systems attached without
-          turning them into the center of the design.
-        </li>
-      </ul>
-    </section>
-
-    <section className="space-y-4">
-      <h2>Why this helps in real programs</h2>
-      <p>
-        On mobile programs, it keeps device and channel concerns from taking
-        over core business logic. In system integration and enterprise
-        modernization work, it prevents a vendor interface from becoming the
-        architecture. In AI-enabled workflows, it creates a safe place for
-        retrieval, reasoning, and validation without promoting the model to
-        system authority.
-      </p>
-      <p>
-        It also supports replacement. A mobile client can be rebuilt, an ERP
-        connector can be swapped, or an AI provider can change without forcing a
-        redesign of the domain. That is the point of keeping the boundaries
-        clear.
-      </p>
-      <p>
-        The operational side of that same argument shows up in{" "}
-        <PostLink slug="secure-platform-integration-is-not-plumbing">
-          Secure Platform Integration Is Not Plumbing
-        </PostLink>
-        , where the integration layer is treated as a control surface rather
-        than a transport detail.
-      </p>
-    </section>
-
-    <section className="space-y-4">
-      <h2>Conclusion</h2>
-      <p>
-        Software layers are not only a code-organization preference. They are
-        risk boundaries. They decide whether business rules stay durable,
-        whether integrations remain replaceable, and whether runtime concerns
-        can change without pulling the whole system apart.
-      </p>
-    </section>
-  </>
-)
 
 export const blogPosts: BlogPost[] = [
   {
@@ -258,7 +89,6 @@ export const blogPosts: BlogPost[] = [
       slug: "architecture-control-boundaries",
       order: 3,
     },
-    Content: softwareLayersRiskBoundariesContent,
   },
 ]
 

--- a/app/routes/blog.software-layers-are-risk-boundaries/content.mdx
+++ b/app/routes/blog.software-layers-are-risk-boundaries/content.mdx
@@ -1,0 +1,72 @@
+---
+slug: software-layers-are-risk-boundaries
+status: published
+title: Software Layers Are Risk Boundaries
+description: Why layered architecture keeps business rules, integration boundaries, security decisions, and runtime concerns from collapsing into each other.
+date: "2026-04-24"
+excerpt: Layering is how mobile, integration, and AI-enabled systems stay governable when vendors, channels, and runtime concerns change around them.
+tags:
+  - architecture-notes
+  - layered-architecture
+  - mobile-systems
+  - enterprise-architecture
+relatedSlugs:
+  - secure-platform-integration-is-not-plumbing
+  - ai-pipelines-need-control-boundaries
+series:
+  slug: architecture-control-boundaries
+  order: 3
+---
+
+## Why layers still matter
+
+Layered architecture matters because it is one of the simplest ways to keep risk from collapsing into a single code path. Without layers, interface concerns, business rules, integration behavior, and infrastructure choices drift together until every change becomes a coupled change.
+
+The useful question is not whether the layers are academically pure. It is whether they preserve replaceability and make failure easier to localize.
+
+<Figure
+  title="Software layers as risk boundaries"
+  caption="Each layer contains a different kind of change so clients, policy, and vendor concerns do not collapse into one code path."
+  src="/img/blog/software_layers_diagram.svg"
+  alt="Diagram showing clients flowing into interface and application layers, with the application layer connected to both domain and infrastructure."
+/>
+
+## Clients and channels
+
+Mobile apps, browser clients, partner interfaces, background jobs, and operator tools all enter the system from different conditions. Their job is to collect intent and present results. They should not become the place where core workflow rules are defined.
+
+## Interface layer
+
+The interface layer translates between external protocols and internal use cases. It handles transport concerns such as request validation, authentication context, response shaping, and correlation identifiers. It should not be the home of domain policy.
+
+## Application layer
+
+The application layer coordinates workflows. It decides what needs to happen in what order, which policies apply, and which collaborators need to be invoked. This is where enterprise process shape belongs, including AI-assisted steps, approval gates, and integration sequencing.
+
+## Domain layer
+
+The domain layer protects business meaning: state transitions, invariants, eligibility rules, and the definitions that make the system more than a collection of endpoints. It should remain understandable without reference to a UI framework, ERP connector, or model provider.
+
+## Infrastructure and adapters
+
+Infrastructure is where databases, queues, vendor SDKs, ERP connectors, mobile platform services, and model providers live. These adapters are necessary, but they should remain replaceable. When they leak upward into policy code, vendor replacement becomes a rewrite instead of an integration task.
+
+## Why each layer exists
+
+- Clients and channels isolate user-facing behavior and device-specific constraints.
+- The interface layer protects the system from protocol churn and input ambiguity.
+- The application layer governs workflow sequencing and approvals.
+- The domain layer preserves business rules independent of tools and vendors.
+- Infrastructure and adapters keep external systems attached without turning them into the center of the design.
+
+## Why this helps in real programs
+
+On mobile programs, it keeps device and channel concerns from taking over core business logic. In system integration and enterprise modernization work, it prevents a vendor interface from becoming the architecture. In AI-enabled workflows, it creates a safe place for retrieval, reasoning, and validation without promoting the model to system authority.
+
+It also supports replacement. A mobile client can be rebuilt, an ERP connector can be swapped, or an AI provider can change without forcing a redesign of the domain. That is the point of keeping the boundaries clear.
+
+The operational side of that same argument shows up in <PostLink slug="secure-platform-integration-is-not-plumbing">Secure Platform Integration Is Not Plumbing</PostLink>, where the integration layer is treated as a control surface rather than a transport detail.
+
+## Conclusion
+
+Software layers are not only a code-organization preference. They are risk boundaries. They decide whether business rules stay durable, whether integrations remain replaceable, and whether runtime concerns can change without pulling the whole system apart.

--- a/app/routes/blog.software-layers-are-risk-boundaries/route.tsx
+++ b/app/routes/blog.software-layers-are-risk-boundaries/route.tsx
@@ -1,0 +1,139 @@
+import type { MetaFunction } from "@remix-run/node"
+
+import { BlogArticleLayout } from "~/components/blog-article-layout"
+import { blogMdxComponents } from "~/components/blog-mdx-components"
+import type { BlogPost } from "~/content/blog"
+import { getBlogPostBySlug } from "~/content/blog-provider"
+import { assertRoutableMdxPublication } from "~/content/blog-publication.js"
+import { buildArticleMeta, buildArticleStructuredData } from "~/utils/seo"
+
+import Content, { attributes } from "./content.mdx"
+
+const EXPECTED_SLUG = "software-layers-are-risk-boundaries"
+
+function requiredString(name: string) {
+  const value = attributes[name]
+
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`Invalid MDX frontmatter field: ${name}`)
+  }
+
+  return value
+}
+
+function requiredStringArray(name: string) {
+  const value = attributes[name]
+
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    value.some((item) => typeof item !== "string" || item.trim() === "")
+  ) {
+    throw new Error(`Invalid MDX frontmatter field: ${name}`)
+  }
+
+  const normalized = value.map((item) => item.trim())
+
+  if (new Set(normalized).size !== normalized.length) {
+    throw new Error(`Duplicate values in MDX frontmatter field: ${name}`)
+  }
+
+  return normalized
+}
+
+function requiredSeries() {
+  const value = attributes.series
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Invalid MDX frontmatter field: series")
+  }
+
+  const series = value as Record<string, unknown>
+  const slug = series.slug
+  const order = series.order
+
+  if (typeof slug !== "string" || slug.trim() === "") {
+    throw new Error("Invalid MDX frontmatter field: series.slug")
+  }
+
+  if (typeof order !== "number" || !Number.isInteger(order) || order < 1) {
+    throw new Error("Invalid MDX frontmatter field: series.order")
+  }
+
+  return {
+    slug: slug.trim(),
+    order,
+  }
+}
+
+const slug = requiredString("slug")
+const date = requiredString("date")
+const status = requiredString("status")
+
+if (slug !== EXPECTED_SLUG) {
+  throw new Error(`MDX slug ${slug} does not match route ${EXPECTED_SLUG}`)
+}
+
+if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || Number.isNaN(Date.parse(date))) {
+  throw new Error(`Invalid MDX publication date: ${date}`)
+}
+
+assertRoutableMdxPublication({ slug, date, status }, { cutoff: date })
+
+const post: BlogPost = {
+  slug,
+  title: requiredString("title"),
+  description: requiredString("description"),
+  date,
+  excerpt: requiredString("excerpt"),
+  tags: requiredStringArray("tags"),
+  relatedSlugs: requiredStringArray("relatedSlugs"),
+  series: requiredSeries(),
+}
+
+const registryPost = getBlogPostBySlug(post.slug)
+
+if (!registryPost) {
+  throw new Error(`Missing registry metadata for MDX post: ${post.slug}`)
+}
+
+for (const field of ["title", "description", "date", "excerpt"] as const) {
+  if (registryPost[field] !== post[field]) {
+    throw new Error(`MDX frontmatter differs from registry field: ${field}`)
+  }
+}
+
+for (const field of ["tags", "relatedSlugs", "series"] as const) {
+  if (JSON.stringify(registryPost[field]) !== JSON.stringify(post[field])) {
+    throw new Error(`MDX frontmatter differs from registry field: ${field}`)
+  }
+}
+
+export const meta: MetaFunction = () =>
+  buildArticleMeta({
+    title: post.title,
+    description: post.description,
+    path: `/blog/${post.slug}`,
+    publishedTime: `${post.date}T00:00:00Z`,
+    tags: post.tags,
+  })
+
+export const handle = {
+  structuredData: buildArticleStructuredData({
+    title: post.title,
+    description: post.description,
+    path: `/blog/${post.slug}`,
+    datePublished: `${post.date}T00:00:00Z`,
+    keywords: post.tags,
+  }),
+}
+
+export default function SoftwareLayersRiskBoundariesRoute() {
+  return (
+    <BlogArticleLayout post={post}>
+      <div data-content-source="mdx">
+        <Content components={blogMdxComponents} />
+      </div>
+    </BlogArticleLayout>
+  )
+}

--- a/e2e/mdx.spec.ts
+++ b/e2e/mdx.spec.ts
@@ -4,8 +4,7 @@ const aiArticlePath = "/blog/ai-pipelines-need-control-boundaries"
 const integrationArticlePath =
   "/blog/secure-platform-integration-is-not-plumbing"
 const softwareLayersArticlePath = "/blog/software-layers-are-risk-boundaries"
-const legacyArticlePath =
-  "/blog/governance-native-engineering-control-plane"
+const legacyArticlePath = "/blog/governance-native-engineering-control-plane"
 
 const unpublishedArticlePaths = [
   "/blog/draft-publication-fixture",
@@ -135,7 +134,9 @@ test.describe("MDX articles", () => {
     )
   })
 
-  test("renders software layers article from canonical MDX", async ({ page }) => {
+  test("renders software layers article from canonical MDX", async ({
+    page,
+  }) => {
     await page.goto(softwareLayersArticlePath)
 
     await expect(page).toHaveTitle(

--- a/e2e/mdx.spec.ts
+++ b/e2e/mdx.spec.ts
@@ -3,7 +3,9 @@ import { expect, test } from "@playwright/test"
 const aiArticlePath = "/blog/ai-pipelines-need-control-boundaries"
 const integrationArticlePath =
   "/blog/secure-platform-integration-is-not-plumbing"
-const legacyArticlePath = "/blog/software-layers-are-risk-boundaries"
+const softwareLayersArticlePath = "/blog/software-layers-are-risk-boundaries"
+const legacyArticlePath =
+  "/blog/governance-native-engineering-control-plane"
 
 const unpublishedArticlePaths = [
   "/blog/draft-publication-fixture",
@@ -40,7 +42,7 @@ test.describe("MDX articles", () => {
       seriesNavigation.getByRole("link", {
         name: "Next: Software Layers Are Risk Boundaries",
       }),
-    ).toHaveAttribute("href", legacyArticlePath)
+    ).toHaveAttribute("href", softwareLayersArticlePath)
 
     const mdxContent = page.locator('[data-content-source="mdx"]')
 
@@ -64,7 +66,7 @@ test.describe("MDX articles", () => {
         name: "Software Layers Are Risk Boundaries",
         exact: true,
       }),
-    ).toHaveAttribute("href", legacyArticlePath)
+    ).toHaveAttribute("href", softwareLayersArticlePath)
 
     await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
       "href",
@@ -133,23 +135,73 @@ test.describe("MDX articles", () => {
     )
   })
 
+  test("renders software layers article from canonical MDX", async ({ page }) => {
+    await page.goto(softwareLayersArticlePath)
+
+    await expect(page).toHaveTitle(
+      "Micrantha Software | Software Layers Are Risk Boundaries",
+    )
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: "Software Layers Are Risk Boundaries",
+      }),
+    ).toBeVisible()
+    await expect(page.getByText("Part 3 of 3", { exact: true })).toBeVisible()
+
+    const seriesNavigation = page.getByRole("navigation", {
+      name: "Architecture Control Boundaries series navigation",
+    })
+
+    await expect(
+      seriesNavigation.getByRole("link", {
+        name: "Previous: AI Pipelines Need Control Boundaries",
+      }),
+    ).toHaveAttribute("href", aiArticlePath)
+    await expect(
+      seriesNavigation.getByRole("link", { name: /^Next:/ }),
+    ).toHaveCount(0)
+
+    const mdxContent = page.locator('[data-content-source="mdx"]')
+
+    await expect(mdxContent).toBeVisible()
+    await expect(
+      mdxContent.getByRole("img", {
+        name: /clients flowing into interface and application layers/i,
+      }),
+    ).toBeVisible()
+    await expect(
+      mdxContent.getByRole("link", {
+        name: "Secure Platform Integration Is Not Plumbing",
+        exact: true,
+      }),
+    ).toHaveAttribute("href", integrationArticlePath)
+    await expect(mdxContent).toContainText(
+      "Software layers are not only a code-organization preference",
+    )
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+      "href",
+      "https://micrantha.com/blog/software-layers-are-risk-boundaries",
+    )
+  })
+
   test("supports hydrated client navigation", async ({ page }) => {
-    await page.goto(integrationArticlePath)
+    await page.goto(softwareLayersArticlePath)
     await page
       .locator('[data-content-source="mdx"]')
       .getByRole("link", {
-        name: "AI Pipelines Need Control Boundaries",
+        name: "Secure Platform Integration Is Not Plumbing",
         exact: true,
       })
       .click()
 
     await expect(page).toHaveURL(
-      /\/blog\/ai-pipelines-need-control-boundaries$/,
+      /\/blog\/secure-platform-integration-is-not-plumbing$/,
     )
     await expect(
       page.getByRole("heading", {
         level: 1,
-        name: "AI Pipelines Need Control Boundaries",
+        name: "Secure Platform Integration Is Not Plumbing",
       }),
     ).toBeVisible()
   })
@@ -164,13 +216,11 @@ test("remaining legacy TSX article continues through the dynamic route", async (
   await expect(
     page.getByRole("heading", {
       level: 1,
-      name: "Software Layers Are Risk Boundaries",
+      name: "Governance-Native Engineering and the AI Control Plane",
     }),
   ).toBeVisible()
   await expect(page.locator('[data-content-source="mdx"]')).toHaveCount(0)
-  await expect(page.locator("main")).toContainText(
-    "Software layers are not only a code-organization preference",
-  )
+  await expect(page.locator("[data-mermaid-diagram]").first()).toBeVisible()
 })
 
 test("draft and future blog URLs remain unavailable", async ({ page }) => {
@@ -237,5 +287,36 @@ test.describe("MDX articles without JavaScript", () => {
         name: /channels and source systems flowing through an API gateway/i,
       }),
     ).toBeVisible()
+  })
+
+  test("returns complete server-rendered software layers content", async ({
+    page,
+  }) => {
+    const response = await page.goto(softwareLayersArticlePath)
+
+    expect(response?.status()).toBe(200)
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: "Software Layers Are Risk Boundaries",
+      }),
+    ).toBeVisible()
+
+    const mdxContent = page.locator('[data-content-source="mdx"]')
+
+    await expect(mdxContent).toContainText(
+      "Software layers are not only a code-organization preference",
+    )
+    await expect(
+      mdxContent.getByRole("img", {
+        name: /clients flowing into interface and application layers/i,
+      }),
+    ).toBeVisible()
+    await expect(
+      mdxContent.getByRole("link", {
+        name: "Secure Platform Integration Is Not Plumbing",
+        exact: true,
+      }),
+    ).toHaveAttribute("href", integrationArticlePath)
   })
 })

--- a/scripts/test-cloudflare-adapter.js
+++ b/scripts/test-cloudflare-adapter.js
@@ -116,16 +116,16 @@ const softwareLayersArticle = await read(
   "/blog/software-layers-are-risk-boundaries",
 )
 assert.equal(softwareLayersArticle.response.status, 200)
-assert.match(
-  softwareLayersArticle.body,
-  /Software Layers Are Risk Boundaries/,
-)
+assert.match(softwareLayersArticle.body, /Software Layers Are Risk Boundaries/)
 assert.match(
   softwareLayersArticle.body,
   /Software layers are not only a code-organization preference/,
 )
 assert.match(softwareLayersArticle.body, /data-content-source="mdx"/)
-assertDocumentHeaders(softwareLayersArticle.response, softwareLayersArticle.body)
+assertDocumentHeaders(
+  softwareLayersArticle.response,
+  softwareLayersArticle.body,
+)
 
 const botArticle = await read("/blog/ai-pipelines-need-control-boundaries", {
   userAgent: "Googlebot/2.1",

--- a/scripts/test-cloudflare-adapter.js
+++ b/scripts/test-cloudflare-adapter.js
@@ -112,6 +112,21 @@ assert.match(
 assert.match(integrationArticle.body, /data-content-source="mdx"/)
 assertDocumentHeaders(integrationArticle.response, integrationArticle.body)
 
+const softwareLayersArticle = await read(
+  "/blog/software-layers-are-risk-boundaries",
+)
+assert.equal(softwareLayersArticle.response.status, 200)
+assert.match(
+  softwareLayersArticle.body,
+  /Software Layers Are Risk Boundaries/,
+)
+assert.match(
+  softwareLayersArticle.body,
+  /Software layers are not only a code-organization preference/,
+)
+assert.match(softwareLayersArticle.body, /data-content-source="mdx"/)
+assertDocumentHeaders(softwareLayersArticle.response, softwareLayersArticle.body)
+
 const botArticle = await read("/blog/ai-pipelines-need-control-boundaries", {
   userAgent: "Googlebot/2.1",
 })


### PR DESCRIPTION
## Summary

- migrate `Software Layers Are Risk Boundaries` from its inline TSX renderer to canonical build-time MDX
- preserve exact metadata, prose, series position, diagram, related link, canonical URL, and structured data
- add the native static route `blog.software-layers-are-risk-boundaries`
- remove the final inline article body from `app/content/blog.tsx`, leaving that registry metadata-only
- move the legacy dynamic-route regression control to the governance-native article registry
- verify all three Architecture Control Boundaries articles through grammar/publication boundaries, desktop/mobile Chromium, hydrated navigation, JavaScript-disabled SSR, and the production Pages adapter

## Runtime boundary

All three architecture articles are compiled into the Remix/Cloudflare build. No request-time source parsing, filesystem content access, or externally supplied MDX is introduced.

## Validation

Successful required CI run: `30879175894` on head `24a3358ff3bbae7e5198b2223b965aab01202109`.

### Quality — passed

- publication unit tests and enforced coverage thresholds
- repository formatting and lint
- approved MDX grammar and local-asset validation for all three static architecture routes
- publication, registry, series, related-slug, sitemap, and renderer boundaries
- metadata-only architecture registry with no inline article renderer
- TypeScript and production Remix builds
- pinned Wrangler and Worker bundle budget
- direct Pages adapter and source-isolated workerd integration contracts

### End-to-end — passed

- complete desktop/mobile functional Chromium suite
- beginning, middle, and end series navigation
- canonical metadata, diagram, related link, and complete article content
- hydrated navigation between static MDX routes
- complete JavaScript-disabled rendering
- governance-native dynamic TSX regression control
- staged workerd hydration and browser-error contracts
- no failure artifacts

Progresses #55; does not close it.