### PR TITLE
Migrate replayability article to MDX

### DIFF
--- a/app/content/blog-governance-native.tsx
+++ b/app/content/blog-governance-native.tsx
@@ -1,96 +1,6 @@
 import { MermaidDiagram } from "~/components"
 import type { BlogPost } from "~/content/blog"
 
-const replayabilityGovernanceContent = () => (
-  <>
-    <section className="space-y-4">
-      <h2>Determinism is not the whole problem</h2>
-      <p>
-        Most conversations around AI reproducibility focus on determinism. That
-        matters, but deterministic replay is only one part of the problem. The
-        larger issue is governance: whether an organization can explain what
-        happened, why it happened, under whose authority it happened, and what
-        evidence still exists to support that claim.
-      </p>
-      <div className="article-callout">
-        <p>
-          Replayability in AI-native systems is not just reproducibility
-          engineering. It is governance infrastructure.
-        </p>
-      </div>
-    </section>
-
-    <MermaidDiagram
-      title="Replayability as evidence lifecycle"
-      caption="Replay confidence depends on captured evidence and decays as provider and runtime facts expire."
-      chart={`flowchart TD
-  A[Execution request] --> B[Provider routing decision]
-  B --> C[Model response]
-  C --> D[Replay envelope]
-  D --> E[Audit or review]
-  D --> F[Evidence decay]
-  F --> G{Replay claim still valid?}
-  G -->|yes| E
-  G -->|no| H[Downgrade replayability claim]`}
-    />
-
-    <section className="space-y-4">
-      <h2>Replayability vs reproducibility</h2>
-      <p>
-        Traditional software systems often assume identical binaries, stable
-        execution environments, deterministic inputs, and recoverable runtime
-        state. AI systems violate many of those assumptions.
-      </p>
-      <p>
-        Providers change. Models mutate. Routing changes. Retention windows
-        expire. Metadata disappears. As a result, replayability becomes an
-        evidence problem, not only a runtime problem.
-      </p>
-    </section>
-
-    <section className="space-y-4">
-      <h2>Replayability ceilings</h2>
-      <p>
-        Different inference providers support different replayability ceilings.
-        A local deterministic runtime and a shared external provider may expose
-        compatible APIs while offering radically different replay guarantees.
-      </p>
-      <p>
-        Replayability must therefore be explicit, policy-aware, evidence-backed,
-        and surfaced to governance systems rather than hidden behind SDK
-        abstractions.
-      </p>
-    </section>
-
-    <section className="space-y-4">
-      <h2>Replayability decay</h2>
-      <p>
-        Replayability is not static. It decays over time as models are replaced,
-        provider attestations expire, evidence is garbage-collected, execution
-        metadata disappears, and retention windows close.
-      </p>
-      <p>
-        Governance systems should model that decay explicitly. A system should
-        not silently preserve a stronger replayability claim after the evidence
-        required to support it has expired.
-      </p>
-    </section>
-
-    <section className="space-y-4">
-      <h2>Anthesis perspective</h2>
-      <p>
-        Anthesis treats replayability as a first-class governance surface.
-        Replay evidence is attached to workflow execution, provider routing,
-        execution lineage, policy evaluation, and governance signals.
-      </p>
-      <p>
-        The goal is not perfect determinism. The goal is bounded explainability
-        and attributable execution.
-      </p>
-    </section>
-  </>
-)
-
 const recursiveGovernanceContent = () => (
   <>
     <section className="space-y-4">
@@ -224,7 +134,6 @@ export const governanceNativeBlogPosts: BlogPost[] = [
       slug: "governance-native-engineering",
       order: 2,
     },
-    Content: replayabilityGovernanceContent,
   },
   {
     slug: "recursive-governance-and-agent-workflows",

--- a/app/routes/blog.replayability-is-a-governance-problem/content.mdx
+++ b/app/routes/blog.replayability-is-a-governance-problem/content.mdx
@@ -1,0 +1,67 @@
+---
+slug: replayability-is-a-governance-problem
+status: published
+title: Replayability Is a Governance Problem
+description: Replayability in AI-native systems is not just reproducibility engineering. It is governance infrastructure.
+date: "2026-05-18"
+excerpt: Replayability becomes an evidence problem when providers change, models mutate, routing shifts, retention windows expire, and metadata disappears.
+tags:
+  - ai-governance
+  - replayability
+  - anthesis
+  - architecture-notes
+relatedSlugs:
+  - governance-native-engineering-control-plane
+  - recursive-governance-and-agent-workflows
+series:
+  slug: governance-native-engineering
+  order: 2
+---
+
+## Determinism is not the whole problem
+
+Most conversations around AI reproducibility focus on determinism. That matters, but deterministic replay is only one part of the problem. The larger issue is governance: whether an organization can explain what happened, why it happened, under whose authority it happened, and what evidence still exists to support that claim.
+
+<Callout>
+
+Replayability in AI-native systems is not just reproducibility engineering. It is governance infrastructure.
+
+</Callout>
+
+```mermaid
+%% title: Replayability as evidence lifecycle
+%% caption: Replay confidence depends on captured evidence and decays as provider and runtime facts expire.
+flowchart TD
+  A[Execution request] --> B[Provider routing decision]
+  B --> C[Model response]
+  C --> D[Replay envelope]
+  D --> E[Audit or review]
+  D --> F[Evidence decay]
+  F --> G{Replay claim still valid?}
+  G -->|yes| E
+  G -->|no| H[Downgrade replayability claim]
+```
+
+## Replayability vs reproducibility
+
+Traditional software systems often assume identical binaries, stable execution environments, deterministic inputs, and recoverable runtime state. AI systems violate many of those assumptions.
+
+Providers change. Models mutate. Routing changes. Retention windows expire. Metadata disappears. As a result, replayability becomes an evidence problem, not only a runtime problem.
+
+## Replayability ceilings
+
+Different inference providers support different replayability ceilings. A local deterministic runtime and a shared external provider may expose compatible APIs while offering radically different replay guarantees.
+
+Replayability must therefore be explicit, policy-aware, evidence-backed, and surfaced to governance systems rather than hidden behind SDK abstractions.
+
+## Replayability decay
+
+Replayability is not static. It decays over time as models are replaced, provider attestations expire, evidence is garbage-collected, execution metadata disappears, and retention windows close.
+
+Governance systems should model that decay explicitly. A system should not silently preserve a stronger replayability claim after the evidence required to support it has expired.
+
+## Anthesis perspective
+
+Anthesis treats replayability as a first-class governance surface. Replay evidence is attached to workflow execution, provider routing, execution lineage, policy evaluation, and governance signals.
+
+The goal is not perfect determinism. The goal is bounded explainability and attributable execution.

--- a/app/routes/blog.replayability-is-a-governance-problem/route.tsx
+++ b/app/routes/blog.replayability-is-a-governance-problem/route.tsx
@@ -1,0 +1,139 @@
+import type { MetaFunction } from "@remix-run/node"
+
+import { BlogArticleLayout } from "~/components/blog-article-layout"
+import { blogMdxComponents } from "~/components/blog-mdx-components"
+import type { BlogPost } from "~/content/blog"
+import { getBlogPostBySlug } from "~/content/blog-provider"
+import { assertRoutableMdxPublication } from "~/content/blog-publication.js"
+import { buildArticleMeta, buildArticleStructuredData } from "~/utils/seo"
+
+import Content, { attributes } from "./content.mdx"
+
+const EXPECTED_SLUG = "replayability-is-a-governance-problem"
+
+function requiredString(name: string) {
+  const value = attributes[name]
+
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`Invalid MDX frontmatter field: ${name}`)
+  }
+
+  return value
+}
+
+function requiredStringArray(name: string) {
+  const value = attributes[name]
+
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    value.some((item) => typeof item !== "string" || item.trim() === "")
+  ) {
+    throw new Error(`Invalid MDX frontmatter field: ${name}`)
+  }
+
+  const normalized = value.map((item) => item.trim())
+
+  if (new Set(normalized).size !== normalized.length) {
+    throw new Error(`Duplicate values in MDX frontmatter field: ${name}`)
+  }
+
+  return normalized
+}
+
+function requiredSeries() {
+  const value = attributes.series
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Invalid MDX frontmatter field: series")
+  }
+
+  const series = value as Record<string, unknown>
+  const slug = series.slug
+  const order = series.order
+
+  if (typeof slug !== "string" || slug.trim() === "") {
+    throw new Error("Invalid MDX frontmatter field: series.slug")
+  }
+
+  if (typeof order !== "number" || !Number.isInteger(order) || order < 1) {
+    throw new Error("Invalid MDX frontmatter field: series.order")
+  }
+
+  return {
+    slug: slug.trim(),
+    order,
+  }
+}
+
+const slug = requiredString("slug")
+const date = requiredString("date")
+const status = requiredString("status")
+
+if (slug !== EXPECTED_SLUG) {
+  throw new Error(`MDX slug ${slug} does not match route ${EXPECTED_SLUG}`)
+}
+
+if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || Number.isNaN(Date.parse(date))) {
+  throw new Error(`Invalid MDX publication date: ${date}`)
+}
+
+assertRoutableMdxPublication({ slug, date, status }, { cutoff: date })
+
+const post: BlogPost = {
+  slug,
+  title: requiredString("title"),
+  description: requiredString("description"),
+  date,
+  excerpt: requiredString("excerpt"),
+  tags: requiredStringArray("tags"),
+  relatedSlugs: requiredStringArray("relatedSlugs"),
+  series: requiredSeries(),
+}
+
+const registryPost = getBlogPostBySlug(post.slug)
+
+if (!registryPost) {
+  throw new Error(`Missing registry metadata for MDX post: ${post.slug}`)
+}
+
+for (const field of ["title", "description", "date", "excerpt"] as const) {
+  if (registryPost[field] !== post[field]) {
+    throw new Error(`MDX frontmatter differs from registry field: ${field}`)
+  }
+}
+
+for (const field of ["tags", "relatedSlugs", "series"] as const) {
+  if (JSON.stringify(registryPost[field]) !== JSON.stringify(post[field])) {
+    throw new Error(`MDX frontmatter differs from registry field: ${field}`)
+  }
+}
+
+export const meta: MetaFunction = () =>
+  buildArticleMeta({
+    title: post.title,
+    description: post.description,
+    path: `/blog/${post.slug}`,
+    publishedTime: `${post.date}T00:00:00Z`,
+    tags: post.tags,
+  })
+
+export const handle = {
+  structuredData: buildArticleStructuredData({
+    title: post.title,
+    description: post.description,
+    path: `/blog/${post.slug}`,
+    datePublished: `${post.date}T00:00:00Z`,
+    keywords: post.tags,
+  }),
+}
+
+export default function ReplayabilityGovernanceRoute() {
+  return (
+    <BlogArticleLayout post={post}>
+      <div data-content-source="mdx">
+        <Content components={blogMdxComponents} />
+      </div>
+    </BlogArticleLayout>
+  )
+}

--- a/e2e/mdx.spec.ts
+++ b/e2e/mdx.spec.ts
@@ -6,7 +6,8 @@ const integrationArticlePath =
 const softwareLayersArticlePath = "/blog/software-layers-are-risk-boundaries"
 const governanceArticlePath =
   "/blog/governance-native-engineering-control-plane"
-const legacyArticlePath = "/blog/replayability-is-a-governance-problem"
+const replayabilityArticlePath = "/blog/replayability-is-a-governance-problem"
+const legacyArticlePath = "/blog/recursive-governance-and-agent-workflows"
 
 const unpublishedArticlePaths = [
   "/blog/draft-publication-fixture",
@@ -212,7 +213,7 @@ test.describe("MDX articles", () => {
       seriesNavigation.getByRole("link", {
         name: "Next: Replayability Is a Governance Problem",
       }),
-    ).toHaveAttribute("href", legacyArticlePath)
+    ).toHaveAttribute("href", replayabilityArticlePath)
     await expect(
       seriesNavigation.getByRole("link", { name: /^Previous:/ }),
     ).toHaveCount(0)
@@ -235,6 +236,57 @@ test.describe("MDX articles", () => {
     await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
       "href",
       "https://micrantha.com/blog/governance-native-engineering-control-plane",
+    )
+  })
+
+  test("renders replayability article and Mermaid from canonical MDX", async ({
+    page,
+  }) => {
+    await page.goto(replayabilityArticlePath)
+
+    await expect(page).toHaveTitle(
+      "Micrantha Software | Replayability Is a Governance Problem",
+    )
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: "Replayability Is a Governance Problem",
+      }),
+    ).toBeVisible()
+    await expect(page.getByText("Part 2 of 3", { exact: true })).toBeVisible()
+
+    const seriesNavigation = page.getByRole("navigation", {
+      name: "Governance-Native Engineering series navigation",
+    })
+
+    await expect(
+      seriesNavigation.getByRole("link", {
+        name: "Previous: Governance-Native Engineering and the AI Control Plane",
+      }),
+    ).toHaveAttribute("href", governanceArticlePath)
+    await expect(
+      seriesNavigation.getByRole("link", {
+        name: "Next: Recursive Governance and Agent Workflows",
+      }),
+    ).toHaveAttribute("href", legacyArticlePath)
+
+    const mdxContent = page.locator('[data-content-source="mdx"]')
+    const diagram = mdxContent.locator("[data-mermaid-diagram]")
+
+    await expect(mdxContent.locator(".article-callout")).toContainText(
+      "Replayability in AI-native systems is not just reproducibility engineering",
+    )
+    await expect(diagram).toContainText("Replayability as evidence lifecycle")
+    await expect(diagram).toHaveAttribute("data-mermaid-status", "rendered", {
+      timeout: 15_000,
+    })
+    await expect(diagram.locator("[data-mermaid-rendered] svg")).toBeVisible()
+    await expect(mdxContent).toContainText(
+      "The goal is bounded explainability and attributable execution",
+    )
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+      "href",
+      "https://micrantha.com/blog/replayability-is-a-governance-problem",
     )
   })
 
@@ -269,7 +321,7 @@ test("remaining legacy TSX article continues through the dynamic route", async (
   await expect(
     page.getByRole("heading", {
       level: 1,
-      name: "Replayability Is a Governance Problem",
+      name: "Recursive Governance and Agent Workflows",
     }),
   ).toBeVisible()
   await expect(page.locator('[data-content-source="mdx"]')).toHaveCount(0)
@@ -395,6 +447,31 @@ test.describe("MDX articles without JavaScript", () => {
     )
     await expect(mdxContent).toContainText(
       "AI-native engineering therefore becomes a systems-governance discipline",
+    )
+  })
+
+  test("returns replayability Mermaid source and complete content", async ({
+    page,
+  }) => {
+    const response = await page.goto(replayabilityArticlePath)
+
+    expect(response?.status()).toBe(200)
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: "Replayability Is a Governance Problem",
+      }),
+    ).toBeVisible()
+
+    const mdxContent = page.locator('[data-content-source="mdx"]')
+    const diagram = mdxContent.locator("[data-mermaid-diagram]")
+
+    await expect(diagram).toHaveAttribute("data-mermaid-status", "source")
+    await expect(diagram.locator("[data-mermaid-source]")).toContainText(
+      "Replay claim still valid?",
+    )
+    await expect(mdxContent).toContainText(
+      "The goal is bounded explainability and attributable execution",
     )
   })
 })

--- a/scripts/test-cloudflare-adapter.js
+++ b/scripts/test-cloudflare-adapter.js
@@ -142,6 +142,20 @@ assert.match(governanceArticle.body, /Human intent/)
 assert.doesNotMatch(governanceArticle.body, /data-mermaid-rendered/)
 assertDocumentHeaders(governanceArticle.response, governanceArticle.body)
 
+const replayabilityArticle = await read(
+  "/blog/replayability-is-a-governance-problem",
+)
+assert.equal(replayabilityArticle.response.status, 200)
+assert.match(
+  replayabilityArticle.body,
+  /Replayability Is a Governance Problem/,
+)
+assert.match(replayabilityArticle.body, /data-content-source="mdx"/)
+assert.match(replayabilityArticle.body, /data-mermaid-status="source"/)
+assert.match(replayabilityArticle.body, /Replay claim still valid\?/)
+assert.doesNotMatch(replayabilityArticle.body, /data-mermaid-rendered/)
+assertDocumentHeaders(replayabilityArticle.response, replayabilityArticle.body)
+
 const botArticle = await read("/blog/ai-pipelines-need-control-boundaries", {
   userAgent: "Googlebot/2.1",
 })

--- a/scripts/test-cloudflare-adapter.js
+++ b/scripts/test-cloudflare-adapter.js
@@ -146,10 +146,7 @@ const replayabilityArticle = await read(
   "/blog/replayability-is-a-governance-problem",
 )
 assert.equal(replayabilityArticle.response.status, 200)
-assert.match(
-  replayabilityArticle.body,
-  /Replayability Is a Governance Problem/,
-)
+assert.match(replayabilityArticle.body, /Replayability Is a Governance Problem/)
 assert.match(replayabilityArticle.body, /data-content-source="mdx"/)
 assert.match(replayabilityArticle.body, /data-mermaid-status="source"/)
 assert.match(replayabilityArticle.body, /Replay claim still valid\?/)


### PR DESCRIPTION
## Summary

- migrate `Replayability Is a Governance Problem` from an inline TSX renderer to canonical build-time MDX
- preserve exact metadata, prose, series order, callout, Mermaid diagram, canonical URL, and structured data
- add the native static route `blog.replayability-is-a-governance-problem`
- remove the duplicate TSX body and renderer pointer
- retain `Recursive Governance and Agent Workflows` as the final dynamic-route regression control
- reuse the shared constrained fenced-Mermaid parser, build boundary, source-first SSR, and strict client enhancement
- verify Part 2 series navigation, desktop/mobile rendering, source-first Pages output, hydrated SVG, and JavaScript-disabled source

## Runtime boundary

The article is compiled into the Remix/Cloudflare build. No request-time filesystem access, source parsing, external MDX, or new executable content surface is introduced.

## Validation intent

Required CI covers:

- publication unit coverage thresholds and Mermaid parser policy
- approved MDX grammar, publication, registry, series, related-slug, sitemap, renderer, and all-route Mermaid boundaries
- formatting, lint, typecheck, production build, Wrangler, and Worker bundle budget
- direct Pages adapter and source-isolated workerd source-first Mermaid contracts
- desktop/mobile metadata, Part 2 navigation, callout, complete content, and final legacy dynamic fallback
- hydrated Mermaid SVG enhancement and JavaScript-disabled source/content

Progresses #55; does not close it.