### PR TITLE
Migrate replayability governance article to MDX

### DIFF
--- a/app/content/blog-governance-native.tsx
+++ b/app/content/blog-governance-native.tsx
@@ -1,96 +1,6 @@
 import { MermaidDiagram } from "~/components"
 import type { BlogPost } from "~/content/blog"
 
-const replayabilityGovernanceContent = () => (
-  <>
-    <section className="space-y-4">
-      <h2>Determinism is not the whole problem</h2>
-      <p>
-        Most conversations around AI reproducibility focus on determinism. That
-        matters, but deterministic replay is only one part of the problem. The
-        larger issue is governance: whether an organization can explain what
-        happened, why it happened, under whose authority it happened, and what
-        evidence still exists to support that claim.
-      </p>
-      <div className="article-callout">
-        <p>
-          Replayability in AI-native systems is not just reproducibility
-          engineering. It is governance infrastructure.
-        </p>
-      </div>
-    </section>
-
-    <MermaidDiagram
-      title="Replayability as evidence lifecycle"
-      caption="Replay confidence depends on captured evidence and decays as provider and runtime facts expire."
-      chart={`flowchart TD
-  A[Execution request] --> B[Provider routing decision]
-  B --> C[Model response]
-  C --> D[Replay envelope]
-  D --> E[Audit or review]
-  D --> F[Evidence decay]
-  F --> G{Replay claim still valid?}
-  G -->|yes| E
-  G -->|no| H[Downgrade replayability claim]`}
-    />
-
-    <section className="space-y-4">
-      <h2>Replayability vs reproducibility</h2>
-      <p>
-        Traditional software systems often assume identical binaries, stable
-        execution environments, deterministic inputs, and recoverable runtime
-        state. AI systems violate many of those assumptions.
-      </p>
-      <p>
-        Providers change. Models mutate. Routing changes. Retention windows
-        expire. Metadata disappears. As a result, replayability becomes an
-        evidence problem, not only a runtime problem.
-      </p>
-    </section>
-
-    <section className="space-y-4">
-      <h2>Replayability ceilings</h2>
-      <p>
-        Different inference providers support different replayability ceilings.
-        A local deterministic runtime and a shared external provider may expose
-        compatible APIs while offering radically different replay guarantees.
-      </p>
-      <p>
-        Replayability must therefore be explicit, policy-aware, evidence-backed,
-        and surfaced to governance systems rather than hidden behind SDK
-        abstractions.
-      </p>
-    </section>
-
-    <section className="space-y-4">
-      <h2>Replayability decay</h2>
-      <p>
-        Replayability is not static. It decays over time as models are replaced,
-        provider attestations expire, evidence is garbage-collected, execution
-        metadata disappears, and retention windows close.
-      </p>
-      <p>
-        Governance systems should model that decay explicitly. A system should
-        not silently preserve a stronger replayability claim after the evidence
-        required to support it has expired.
-      </p>
-    </section>
-
-    <section className="space-y-4">
-      <h2>Anthesis perspective</h2>
-      <p>
-        Anthesis treats replayability as a first-class governance surface.
-        Replay evidence is attached to workflow execution, provider routing,
-        execution lineage, policy evaluation, and governance signals.
-      </p>
-      <p>
-        The goal is not perfect determinism. The goal is bounded explainability
-        and attributable execution.
-      </p>
-    </section>
-  </>
-)
-
 const recursiveGovernanceContent = () => (
   <>
     <section className="space-y-4">
@@ -224,7 +134,6 @@ export const governanceNativeBlogPosts: BlogPost[] = [
       slug: "governance-native-engineering",
       order: 2,
     },
-    Content: replayabilityGovernanceContent,
   },
   {
     slug: "recursive-governance-and-agent-workflows",

--- a/app/routes/blog.replayability-is-a-governance-problem/content.mdx
+++ b/app/routes/blog.replayability-is-a-governance-problem/content.mdx
@@ -1,0 +1,67 @@
+---
+slug: replayability-is-a-governance-problem
+status: published
+title: Replayability Is a Governance Problem
+description: Replayability in AI-native systems is not just reproducibility engineering. It is governance infrastructure.
+date: "2026-05-18"
+excerpt: Replayability becomes an evidence problem when providers change, models mutate, routing shifts, retention windows expire, and metadata disappears.
+tags:
+  - ai-governance
+  - replayability
+  - anthesis
+  - architecture-notes
+relatedSlugs:
+  - governance-native-engineering-control-plane
+  - recursive-governance-and-agent-workflows
+series:
+  slug: governance-native-engineering
+  order: 2
+---
+
+## Determinism is not the whole problem
+
+Most conversations around AI reproducibility focus on determinism. That matters, but deterministic replay is only one part of the problem. The larger issue is governance: whether an organization can explain what happened, why it happened, under whose authority it happened, and what evidence still exists to support that claim.
+
+<Callout>
+
+Replayability in AI-native systems is not just reproducibility engineering. It is governance infrastructure.
+
+</Callout>
+
+```mermaid
+%% title: Replayability as evidence lifecycle
+%% caption: Replay confidence depends on captured evidence and decays as provider and runtime facts expire.
+flowchart TD
+  A[Execution request] --> B[Provider routing decision]
+  B --> C[Model response]
+  C --> D[Replay envelope]
+  D --> E[Audit or review]
+  D --> F[Evidence decay]
+  F --> G{Replay claim still valid?}
+  G -->|yes| E
+  G -->|no| H[Downgrade replayability claim]
+```
+
+## Replayability vs reproducibility
+
+Traditional software systems often assume identical binaries, stable execution environments, deterministic inputs, and recoverable runtime state. AI systems violate many of those assumptions.
+
+Providers change. Models mutate. Routing changes. Retention windows expire. Metadata disappears. As a result, replayability becomes an evidence problem, not only a runtime problem.
+
+## Replayability ceilings
+
+Different inference providers support different replayability ceilings. A local deterministic runtime and a shared external provider may expose compatible APIs while offering radically different replay guarantees.
+
+Replayability must therefore be explicit, policy-aware, evidence-backed, and surfaced to governance systems rather than hidden behind SDK abstractions.
+
+## Replayability decay
+
+Replayability is not static. It decays over time as models are replaced, provider attestations expire, evidence is garbage-collected, execution metadata disappears, and retention windows close.
+
+Governance systems should model that decay explicitly. A system should not silently preserve a stronger replayability claim after the evidence required to support it has expired.
+
+## Anthesis perspective
+
+Anthesis treats replayability as a first-class governance surface. Replay evidence is attached to workflow execution, provider routing, execution lineage, policy evaluation, and governance signals.
+
+The goal is not perfect determinism. The goal is bounded explainability and attributable execution.

--- a/app/routes/blog.replayability-is-a-governance-problem/route.tsx
+++ b/app/routes/blog.replayability-is-a-governance-problem/route.tsx
@@ -1,0 +1,139 @@
+import type { MetaFunction } from "@remix-run/node"
+
+import { BlogArticleLayout } from "~/components/blog-article-layout"
+import { blogMdxComponents } from "~/components/blog-mdx-components"
+import type { BlogPost } from "~/content/blog"
+import { getBlogPostBySlug } from "~/content/blog-provider"
+import { assertRoutableMdxPublication } from "~/content/blog-publication.js"
+import { buildArticleMeta, buildArticleStructuredData } from "~/utils/seo"
+
+import Content, { attributes } from "./content.mdx"
+
+const EXPECTED_SLUG = "replayability-is-a-governance-problem"
+
+function requiredString(name: string) {
+  const value = attributes[name]
+
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`Invalid MDX frontmatter field: ${name}`)
+  }
+
+  return value
+}
+
+function requiredStringArray(name: string) {
+  const value = attributes[name]
+
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    value.some((item) => typeof item !== "string" || item.trim() === "")
+  ) {
+    throw new Error(`Invalid MDX frontmatter field: ${name}`)
+  }
+
+  const normalized = value.map((item) => item.trim())
+
+  if (new Set(normalized).size !== normalized.length) {
+    throw new Error(`Duplicate values in MDX frontmatter field: ${name}`)
+  }
+
+  return normalized
+}
+
+function requiredSeries() {
+  const value = attributes.series
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Invalid MDX frontmatter field: series")
+  }
+
+  const series = value as Record<string, unknown>
+  const slug = series.slug
+  const order = series.order
+
+  if (typeof slug !== "string" || slug.trim() === "") {
+    throw new Error("Invalid MDX frontmatter field: series.slug")
+  }
+
+  if (typeof order !== "number" || !Number.isInteger(order) || order < 1) {
+    throw new Error("Invalid MDX frontmatter field: series.order")
+  }
+
+  return {
+    slug: slug.trim(),
+    order,
+  }
+}
+
+const slug = requiredString("slug")
+const date = requiredString("date")
+const status = requiredString("status")
+
+if (slug !== EXPECTED_SLUG) {
+  throw new Error(`MDX slug ${slug} does not match route ${EXPECTED_SLUG}`)
+}
+
+if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || Number.isNaN(Date.parse(date))) {
+  throw new Error(`Invalid MDX publication date: ${date}`)
+}
+
+assertRoutableMdxPublication({ slug, date, status }, { cutoff: date })
+
+const post: BlogPost = {
+  slug,
+  title: requiredString("title"),
+  description: requiredString("description"),
+  date,
+  excerpt: requiredString("excerpt"),
+  tags: requiredStringArray("tags"),
+  relatedSlugs: requiredStringArray("relatedSlugs"),
+  series: requiredSeries(),
+}
+
+const registryPost = getBlogPostBySlug(post.slug)
+
+if (!registryPost) {
+  throw new Error(`Missing registry metadata for MDX post: ${post.slug}`)
+}
+
+for (const field of ["title", "description", "date", "excerpt"] as const) {
+  if (registryPost[field] !== post[field]) {
+    throw new Error(`MDX frontmatter differs from registry field: ${field}`)
+  }
+}
+
+for (const field of ["tags", "relatedSlugs", "series"] as const) {
+  if (JSON.stringify(registryPost[field]) !== JSON.stringify(post[field])) {
+    throw new Error(`MDX frontmatter differs from registry field: ${field}`)
+  }
+}
+
+export const meta: MetaFunction = () =>
+  buildArticleMeta({
+    title: post.title,
+    description: post.description,
+    path: `/blog/${post.slug}`,
+    publishedTime: `${post.date}T00:00:00Z`,
+    tags: post.tags,
+  })
+
+export const handle = {
+  structuredData: buildArticleStructuredData({
+    title: post.title,
+    description: post.description,
+    path: `/blog/${post.slug}`,
+    datePublished: `${post.date}T00:00:00Z`,
+    keywords: post.tags,
+  }),
+}
+
+export default function ReplayabilityGovernanceRoute() {
+  return (
+    <BlogArticleLayout post={post}>
+      <div data-content-source="mdx">
+        <Content components={blogMdxComponents} />
+      </div>
+    </BlogArticleLayout>
+  )
+}

--- a/e2e/mdx.spec.ts
+++ b/e2e/mdx.spec.ts
@@ -6,7 +6,8 @@ const integrationArticlePath =
 const softwareLayersArticlePath = "/blog/software-layers-are-risk-boundaries"
 const governanceArticlePath =
   "/blog/governance-native-engineering-control-plane"
-const legacyArticlePath = "/blog/replayability-is-a-governance-problem"
+const replayabilityArticlePath = "/blog/replayability-is-a-governance-problem"
+const legacyArticlePath = "/blog/recursive-governance-and-agent-workflows"
 
 const unpublishedArticlePaths = [
   "/blog/draft-publication-fixture",
@@ -212,7 +213,7 @@ test.describe("MDX articles", () => {
       seriesNavigation.getByRole("link", {
         name: "Next: Replayability Is a Governance Problem",
       }),
-    ).toHaveAttribute("href", legacyArticlePath)
+    ).toHaveAttribute("href", replayabilityArticlePath)
     await expect(
       seriesNavigation.getByRole("link", { name: /^Previous:/ }),
     ).toHaveCount(0)
@@ -238,25 +239,83 @@ test.describe("MDX articles", () => {
     )
   })
 
-  test("supports hydrated client navigation", async ({ page }) => {
-    await page.goto(softwareLayersArticlePath)
-    await page
-      .locator('[data-content-source="mdx"]')
-      .getByRole("link", {
-        name: "Secure Platform Integration Is Not Plumbing",
-        exact: true,
-      })
-      .click()
+  test("renders replayability article and Mermaid from canonical MDX", async ({
+    page,
+  }) => {
+    await page.goto(replayabilityArticlePath)
 
-    await expect(page).toHaveURL(
-      /\/blog\/secure-platform-integration-is-not-plumbing$/,
+    await expect(page).toHaveTitle(
+      "Micrantha Software | Replayability Is a Governance Problem",
     )
     await expect(
       page.getByRole("heading", {
         level: 1,
-        name: "Secure Platform Integration Is Not Plumbing",
+        name: "Replayability Is a Governance Problem",
       }),
     ).toBeVisible()
+    await expect(page.getByText("Part 2 of 3", { exact: true })).toBeVisible()
+
+    const seriesNavigation = page.getByRole("navigation", {
+      name: "Governance-Native Engineering series navigation",
+    })
+
+    await expect(
+      seriesNavigation.getByRole("link", {
+        name: "Previous: Governance-Native Engineering and the AI Control Plane",
+      }),
+    ).toHaveAttribute("href", governanceArticlePath)
+    await expect(
+      seriesNavigation.getByRole("link", {
+        name: "Next: Recursive Governance and Agent Workflows",
+      }),
+    ).toHaveAttribute("href", legacyArticlePath)
+
+    const mdxContent = page.locator('[data-content-source="mdx"]')
+    const diagram = mdxContent.locator("[data-mermaid-diagram]")
+
+    await expect(mdxContent).toBeVisible()
+    await expect(mdxContent.locator(".article-callout")).toContainText(
+      "not just reproducibility engineering",
+    )
+    await expect(diagram).toContainText("Replayability as evidence lifecycle")
+    await expect(diagram).toHaveAttribute("data-mermaid-status", "rendered", {
+      timeout: 15_000,
+    })
+    await expect(diagram.locator("[data-mermaid-rendered] svg")).toBeVisible()
+    await expect(mdxContent).toContainText(
+      "The goal is not perfect determinism. The goal is bounded explainability",
+    )
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+      "href",
+      "https://micrantha.com/blog/replayability-is-a-governance-problem",
+    )
+  })
+
+  test("supports hydrated governance-series navigation", async ({ page }) => {
+    await page.goto(governanceArticlePath)
+    await page
+      .getByRole("navigation", {
+        name: "Governance-Native Engineering series navigation",
+      })
+      .getByRole("link", {
+        name: "Next: Replayability Is a Governance Problem",
+      })
+      .click()
+
+    await expect(page).toHaveURL(
+      /\/blog\/replayability-is-a-governance-problem$/,
+    )
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: "Replayability Is a Governance Problem",
+      }),
+    ).toBeVisible()
+    await expect(
+      page
+        .locator('[data-content-source="mdx"]')
+        .locator("[data-mermaid-diagram]"),
+    ).toHaveAttribute("data-mermaid-status", "rendered", { timeout: 15_000 })
   })
 })
 
@@ -269,7 +328,7 @@ test("remaining legacy TSX article continues through the dynamic route", async (
   await expect(
     page.getByRole("heading", {
       level: 1,
-      name: "Replayability Is a Governance Problem",
+      name: "Recursive Governance and Agent Workflows",
     }),
   ).toBeVisible()
   await expect(page.locator('[data-content-source="mdx"]')).toHaveCount(0)
@@ -395,6 +454,31 @@ test.describe("MDX articles without JavaScript", () => {
     )
     await expect(mdxContent).toContainText(
       "AI-native engineering therefore becomes a systems-governance discipline",
+    )
+  })
+
+  test("returns replayability Mermaid source and complete content", async ({
+    page,
+  }) => {
+    const response = await page.goto(replayabilityArticlePath)
+
+    expect(response?.status()).toBe(200)
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: "Replayability Is a Governance Problem",
+      }),
+    ).toBeVisible()
+
+    const mdxContent = page.locator('[data-content-source="mdx"]')
+    const diagram = mdxContent.locator("[data-mermaid-diagram]")
+
+    await expect(diagram).toHaveAttribute("data-mermaid-status", "source")
+    await expect(diagram.locator("[data-mermaid-source]")).toContainText(
+      "Execution request",
+    )
+    await expect(mdxContent).toContainText(
+      "The goal is not perfect determinism. The goal is bounded explainability",
     )
   })
 })

--- a/scripts/test-cloudflare-adapter.js
+++ b/scripts/test-cloudflare-adapter.js
@@ -142,6 +142,25 @@ assert.match(governanceArticle.body, /Human intent/)
 assert.doesNotMatch(governanceArticle.body, /data-mermaid-rendered/)
 assertDocumentHeaders(governanceArticle.response, governanceArticle.body)
 
+const replayabilityArticle = await read(
+  "/blog/replayability-is-a-governance-problem",
+)
+assert.equal(replayabilityArticle.response.status, 200)
+assert.match(
+  replayabilityArticle.body,
+  /Replayability Is a Governance Problem/,
+)
+assert.match(replayabilityArticle.body, /data-content-source="mdx"/)
+assert.match(replayabilityArticle.body, /data-mermaid-status="source"/)
+assert.match(replayabilityArticle.body, /data-mermaid-source="true"/)
+assert.match(replayabilityArticle.body, /Execution request/)
+assert.match(
+  replayabilityArticle.body,
+  /The goal is not perfect determinism\. The goal is bounded explainability/,
+)
+assert.doesNotMatch(replayabilityArticle.body, /data-mermaid-rendered/)
+assertDocumentHeaders(replayabilityArticle.response, replayabilityArticle.body)
+
 const botArticle = await read("/blog/ai-pipelines-need-control-boundaries", {
   userAgent: "Googlebot/2.1",
 })

--- a/scripts/test-cloudflare-adapter.js
+++ b/scripts/test-cloudflare-adapter.js
@@ -146,10 +146,7 @@ const replayabilityArticle = await read(
   "/blog/replayability-is-a-governance-problem",
 )
 assert.equal(replayabilityArticle.response.status, 200)
-assert.match(
-  replayabilityArticle.body,
-  /Replayability Is a Governance Problem/,
-)
+assert.match(replayabilityArticle.body, /Replayability Is a Governance Problem/)
 assert.match(replayabilityArticle.body, /data-content-source="mdx"/)
 assert.match(replayabilityArticle.body, /data-mermaid-status="source"/)
 assert.match(replayabilityArticle.body, /data-mermaid-source="true"/)


### PR DESCRIPTION
## Summary

- migrate `Replayability Is a Governance Problem` from its inline TSX renderer to canonical build-time MDX
- preserve exact metadata, prose, series order, callout, Mermaid diagram, canonical URL, and structured data
- add the native static route `blog.replayability-is-a-governance-problem`
- remove the duplicate TSX body and renderer pointer while retaining `Recursive Governance and Agent Workflows` as the final dynamic-route regression control
- reuse the constrained fenced-Mermaid authoring and fail-closed parser merged in #111

## Branch synchronization

The branch is based on current `main` commit `64200ab4dc9c650be5ce2bd60bf65163c4ddc2e1` and contains only the expected five-file migration delta.

## Validation

CI run `30880812387` passed both required jobs on head `4eff9119ee40e00d804449f85433ea4190aa7695`.

### Quality — passed

- unit tests and enforced coverage thresholds
- formatting and lint
- MDX grammar and Mermaid parser validation
- publication, frontmatter/registry parity, series, related-slug, sitemap, and legacy-renderer boundaries
- TypeScript and production Remix build
- pinned Wrangler and Worker bundle budget
- direct Pages adapter and source-isolated workerd integration contracts

### End-to-end — passed

- complete desktop/mobile functional Playwright suite
- replayability metadata, middle-of-series navigation, callout, complete prose, and canonical URL
- source-first Mermaid SSR and hydrated SVG enhancement
- static-to-static client navigation from the control-plane article
- JavaScript-disabled prose and Mermaid source fallback
- final recursive legacy TSX route regression control
- staged workerd hydration and browser-error contracts
- no failure artifacts

## Runtime boundary

The article and Mermaid source are compiled into the Remix/Cloudflare build. There is no request-time filesystem access, MDX compilation, external content evaluation, or expanded executable component surface.

Supersedes closed duplicate #112. Progresses #55; does not close it.