### PR TITLE
Adopt project-centered site voice

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -169,8 +169,8 @@ export default function Index() {
             Fragile AI delivery
           </p>
           <p className="mt-2 text-sm leading-6 text-slate-700">
-            We help teams move from isolated demos and brittle workflows to
-            systems that fit real engineering environments.
+            Micrantha helps teams move from isolated demos and brittle workflows
+            to systems that fit real engineering environments.
           </p>
         </div>
         <div className="rounded-2xl border border-slate-200 bg-white/80 px-5 py-5 shadow-[0_14px_30px_rgba(31,42,42,0.08)]">
@@ -187,7 +187,7 @@ export default function Index() {
         </div>
         <div className="rounded-2xl border border-slate-200 bg-white/80 px-5 py-5 shadow-[0_14px_30px_rgba(31,42,42,0.08)]">
           <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-600">
-            What We Bring
+            Engineering Approach
           </p>
           <p className="mt-3 text-lg font-semibold tracking-tight text-slate-900">
             Production-minded depth
@@ -212,8 +212,8 @@ export default function Index() {
             systems, and production delivery.
           </h2>
           <p className="mt-3 text-base leading-7 text-slate-700">
-            We help teams turn fragile products, platforms, and workflows into
-            production systems.
+            Micrantha helps teams turn fragile products, platforms, and workflows
+            into production systems.
           </p>
         </div>
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
@@ -247,7 +247,7 @@ export default function Index() {
       <section className="space-y-6 border-t border-gray-200 pt-12">
         <div className="max-w-3xl">
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-600">
-            How We Work
+            Working Approach
           </p>
           <h2 className="mt-2 text-2xl tracking-tight md:text-3xl">
             Built for teams past the demo stage.
@@ -425,8 +425,9 @@ export default function Index() {
           Work that compounds.
         </h2>
         <p className="max-w-3xl text-base leading-7 text-slate-700">
-          We build iteratively, guided by quality, time, and cost. Gardening is
-          our metaphor: tend the soil, grow the seeds, cultivate the garden.
+          Work develops iteratively, guided by quality, time, and cost.
+          Gardening is the metaphor: tend the soil, grow the seeds, cultivate
+          the garden.
         </p>
         <Link className="inline-block text-sm" to="/philosophy">
           Read the full philosophy
@@ -446,7 +447,8 @@ export default function Index() {
               Start the conversation.
             </h2>
             <p className="max-w-2xl text-base leading-7 text-slate-700">
-              For consultations or operational support, reach us directly.
+              For consultations or operational support, contact Micrantha
+              directly.
             </p>
             <div className="flex flex-wrap gap-4 text-sm">
               <a href="mailto:services@micrantha.com">services@micrantha.com</a>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -212,8 +212,8 @@ export default function Index() {
             systems, and production delivery.
           </h2>
           <p className="mt-3 text-base leading-7 text-slate-700">
-            Micrantha helps teams turn fragile products, platforms, and workflows
-            into production systems.
+            Micrantha helps teams turn fragile products, platforms, and
+            workflows into production systems.
           </p>
         </div>
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">

--- a/app/routes/philosophy.tsx
+++ b/app/routes/philosophy.tsx
@@ -166,7 +166,7 @@ const Philosophy = () => {
         <section className="space-y-6">
           <h2 className="text-xl">Metaphor</h2>
           <p>
-            Our working metaphor is gardening: software grows through repeated
+            The working metaphor is gardening: software grows through repeated
             care, environmental support, and patient cultivation over time.
           </p>
           <dl className="grid grid-cols-1 gap-4 md:grid-cols-2">

--- a/app/routes/privacy.tsx
+++ b/app/routes/privacy.tsx
@@ -23,8 +23,8 @@ const Privacy = () => (
           related services.
         </p>
         <p>
-          This page explains how Micrantha collects, uses, and discloses personal
-          information when you use the services.
+          This page explains how Micrantha collects, uses, and discloses
+          personal information when you use the services.
         </p>
         <p>
           By using the service, you agree to the collection and use of
@@ -38,8 +38,8 @@ const Privacy = () => (
         <p>
           For a better experience, Micrantha may ask you to provide personally
           identifiable information, including your name, phone number, or postal
-          address. Micrantha may use that information to contact you, support the
-          service, and improve the experience.
+          address. Micrantha may use that information to contact you, support
+          the service, and improve the experience.
         </p>
       </section>
 
@@ -62,17 +62,17 @@ const Privacy = () => (
         </p>
         <p>
           Micrantha uses cookies to collect information and improve the service.
-          You can accept or refuse cookies, and most browsers let you know when a
-          cookie is being sent. If you refuse cookies, some parts of the service
-          may not function as expected.
+          You can accept or refuse cookies, and most browsers let you know when
+          a cookie is being sent. If you refuse cookies, some parts of the
+          service may not function as expected.
         </p>
       </section>
 
       <section className="space-y-3">
         <h2 className="text-xl">Service Providers</h2>
         <p>
-          Micrantha may use third-party companies and individuals to help operate
-          the service, provide service-related functions, or assist in
+          Micrantha may use third-party companies and individuals to help
+          operate the service, provide service-related functions, or assist in
           understanding how the service is used.
         </p>
         <p>
@@ -104,10 +104,11 @@ const Privacy = () => (
       <section className="space-y-3">
         <h2 className="text-xl">Children&apos;s Privacy</h2>
         <p>
-          Micrantha services are not directed to children under 13, and Micrantha
-          does not knowingly collect personal information from children under 13.
-          If you believe a child has provided personal information, contact
-          privacy@micrantha.com so Micrantha can take appropriate action.
+          Micrantha services are not directed to children under 13, and
+          Micrantha does not knowingly collect personal information from
+          children under 13. If you believe a child has provided personal
+          information, contact privacy@micrantha.com so Micrantha can take
+          appropriate action.
         </p>
       </section>
 

--- a/app/routes/privacy.tsx
+++ b/app/routes/privacy.tsx
@@ -28,17 +28,17 @@ const Privacy = () => (
         </p>
         <p>
           By using the service, you agree to the collection and use of
-          information in accordance with this policy. Personal information is
-          used to provide, operate, and improve the service.
+          information in accordance with this policy. Micrantha uses personal
+          information to provide, operate, and improve the service.
         </p>
       </section>
 
       <section className="space-y-3">
         <h2 className="text-xl">Information Collection and Use</h2>
         <p>
-          For a better experience, the service may ask you to provide personally
+          For a better experience, Micrantha may ask you to provide personally
           identifiable information, including your name, phone number, or postal
-          address. That information may be used to contact you, support the
+          address. Micrantha may use that information to contact you, support the
           service, and improve the experience.
         </p>
       </section>
@@ -46,10 +46,10 @@ const Privacy = () => (
       <section className="space-y-3">
         <h2 className="text-xl">Log Data</h2>
         <p>
-          When you visit the service, information sent automatically by your
-          browser may be collected. This can include your IP address, browser
-          version, the pages you visit, the time and date of your visit, time
-          spent on those pages, and similar diagnostic data.
+          When you visit the service, Micrantha may collect information sent
+          automatically by your browser. This can include your IP address,
+          browser version, the pages you visit, the time and date of your visit,
+          time spent on those pages, and similar diagnostic data.
         </p>
       </section>
 
@@ -71,14 +71,14 @@ const Privacy = () => (
       <section className="space-y-3">
         <h2 className="text-xl">Service Providers</h2>
         <p>
-          Third-party companies and individuals may be used to help operate the
-          service, provide service-related functions, or assist in understanding
-          how the service is used.
+          Micrantha may use third-party companies and individuals to help operate
+          the service, provide service-related functions, or assist in
+          understanding how the service is used.
         </p>
         <p>
           These providers may have access to personal information only as needed
-          to perform those tasks and are expected not to disclose or use it for
-          other purposes.
+          to perform those tasks for Micrantha, and they are expected not to
+          disclose or use it for other purposes.
         </p>
       </section>
 
@@ -87,8 +87,8 @@ const Privacy = () => (
         <p>
           Micrantha uses commercially reasonable measures to protect personal
           information. No method of transmission over the internet or method of
-          electronic storage is completely secure, so absolute security cannot
-          be guaranteed.
+          electronic storage is completely secure, so Micrantha cannot guarantee
+          absolute security.
         </p>
       </section>
 
@@ -104,18 +104,18 @@ const Privacy = () => (
       <section className="space-y-3">
         <h2 className="text-xl">Children&apos;s Privacy</h2>
         <p>
-          Micrantha services are not directed to children under 13, and personal
-          information from children under 13 is not knowingly collected. If you
-          believe a child has provided personal information, contact
-          privacy@micrantha.com so appropriate action can be taken.
+          Micrantha services are not directed to children under 13, and Micrantha
+          does not knowingly collect personal information from children under 13.
+          If you believe a child has provided personal information, contact
+          privacy@micrantha.com so Micrantha can take appropriate action.
         </p>
       </section>
 
       <section className="space-y-3">
         <h2 className="text-xl">Changes to This Privacy Policy</h2>
         <p>
-          This Privacy Policy may be updated from time to time. Changes become
-          effective when they are posted on this page.
+          Micrantha may update this Privacy Policy from time to time. Changes
+          become effective when they are posted on this page.
         </p>
       </section>
 

--- a/app/routes/privacy.tsx
+++ b/app/routes/privacy.tsx
@@ -23,31 +23,31 @@ const Privacy = () => (
           related services.
         </p>
         <p>
-          This page explains how we collect, use, and disclose personal
-          information when you use our services.
+          This page explains how Micrantha collects, uses, and discloses personal
+          information when you use the services.
         </p>
         <p>
           By using the service, you agree to the collection and use of
-          information in accordance with this policy. We use personal
-          information to provide, operate, and improve the service.
+          information in accordance with this policy. Personal information is
+          used to provide, operate, and improve the service.
         </p>
       </section>
 
       <section className="space-y-3">
         <h2 className="text-xl">Information Collection and Use</h2>
         <p>
-          For a better experience while using our service, we may ask you to
-          provide personally identifiable information, including your name,
-          phone number, or postal address. We use that information to contact
-          you, support the service, and improve the experience.
+          For a better experience, the service may ask you to provide personally
+          identifiable information, including your name, phone number, or postal
+          address. That information may be used to contact you, support the
+          service, and improve the experience.
         </p>
       </section>
 
       <section className="space-y-3">
         <h2 className="text-xl">Log Data</h2>
         <p>
-          When you visit the service, we may collect information your browser
-          sends automatically. This can include your IP address, browser
+          When you visit the service, information sent automatically by your
+          browser may be collected. This can include your IP address, browser
           version, the pages you visit, the time and date of your visit, time
           spent on those pages, and similar diagnostic data.
         </p>
@@ -61,70 +61,68 @@ const Privacy = () => (
           stored on your device.
         </p>
         <p>
-          We use cookies to collect information and improve the service. You can
-          accept or refuse cookies, and most browsers let you know when a cookie
-          is being sent. If you refuse cookies, some parts of the service may
-          not function as expected.
+          Micrantha uses cookies to collect information and improve the service.
+          You can accept or refuse cookies, and most browsers let you know when a
+          cookie is being sent. If you refuse cookies, some parts of the service
+          may not function as expected.
         </p>
       </section>
 
       <section className="space-y-3">
         <h2 className="text-xl">Service Providers</h2>
         <p>
-          We may use third-party companies and individuals to help operate the
-          service, provide the service on our behalf, perform service-related
-          work, or assist us in understanding how the service is used.
+          Third-party companies and individuals may be used to help operate the
+          service, provide service-related functions, or assist in understanding
+          how the service is used.
         </p>
         <p>
           These providers may have access to personal information only as needed
-          to perform those tasks for us, and they are expected not to disclose
-          or use it for other purposes.
+          to perform those tasks and are expected not to disclose or use it for
+          other purposes.
         </p>
       </section>
 
       <section className="space-y-3">
         <h2 className="text-xl">Security</h2>
         <p>
-          We use commercially reasonable measures to protect personal
+          Micrantha uses commercially reasonable measures to protect personal
           information. No method of transmission over the internet or method of
-          electronic storage is completely secure, so we cannot guarantee
-          absolute security.
+          electronic storage is completely secure, so absolute security cannot
+          be guaranteed.
         </p>
       </section>
 
       <section className="space-y-3">
         <h2 className="text-xl">Links to Other Sites</h2>
         <p>
-          The service may contain links to third-party sites. If you follow one
-          of those links, you will be directed to a site we do not operate. We
-          recommend reviewing the privacy policy of every external site you
-          visit.
+          The service may contain links to third-party sites. Following one of
+          those links directs you to a site Micrantha does not operate. Review
+          the privacy policy of every external site you visit.
         </p>
       </section>
 
       <section className="space-y-3">
         <h2 className="text-xl">Children&apos;s Privacy</h2>
         <p>
-          Our services are not directed to children under 13, and we do not
-          knowingly collect personal information from children under 13. If you
-          believe a child has provided us with personal information, contact us
-          and we will take appropriate action.
+          Micrantha services are not directed to children under 13, and personal
+          information from children under 13 is not knowingly collected. If you
+          believe a child has provided personal information, contact
+          privacy@micrantha.com so appropriate action can be taken.
         </p>
       </section>
 
       <section className="space-y-3">
         <h2 className="text-xl">Changes to This Privacy Policy</h2>
         <p>
-          We may update this Privacy Policy from time to time. Changes become
+          This Privacy Policy may be updated from time to time. Changes become
           effective when they are posted on this page.
         </p>
       </section>
 
       <section className="space-y-3 border-t border-gray-200 pt-6">
-        <h2 className="text-xl">Contact Us</h2>
+        <h2 className="text-xl">Contact</h2>
         <p>
-          If you have questions or suggestions about this Privacy Policy,
-          contact us at{" "}
+          Questions or suggestions about this Privacy Policy can be sent to{" "}
           <a href="mailto:privacy@micrantha.com">privacy@micrantha.com</a>.
         </p>
       </section>

--- a/app/routes/security.tsx
+++ b/app/routes/security.tsx
@@ -26,8 +26,8 @@ const Security = () => (
     </p>
     <p>
       Include the affected URL, product, component, impact, reproduction steps,
-      proof-of-concept details, and any logs or screenshots that help validate
-      the issue quickly.
+      proof-of-concept details, and any logs or screenshots that help Micrantha
+      validate the issue quickly.
     </p>
 
     <p className="mt-8 font-bold">Scope</p>
@@ -40,8 +40,8 @@ const Security = () => (
 
     <p className="mt-8 font-bold">Good-Faith Research</p>
     <p>
-      Good-faith security research is welcome when it helps improve the security
-      of Micrantha systems.
+      Micrantha welcomes good-faith security research that helps improve the
+      security of Micrantha systems.
     </p>
     <p>Please avoid:</p>
     <ul>
@@ -53,9 +53,9 @@ const Security = () => (
 
     <p className="mt-8 font-bold">What to Expect</p>
     <p>
-      Reports are reviewed, validated, and prioritized for remediation based on
-      severity and impact. For coordinated disclosure, note that in the report
-      and include your preferred contact details.
+      Micrantha reviews reports, validates issues, and prioritizes remediation
+      based on severity and impact. For coordinated disclosure, note that in the
+      report and include your preferred contact details.
     </p>
 
     <p className="mt-8 font-bold">Bug Bounty</p>

--- a/app/routes/security.tsx
+++ b/app/routes/security.tsx
@@ -26,22 +26,22 @@ const Security = () => (
     </p>
     <p>
       Include the affected URL, product, component, impact, reproduction steps,
-      proof-of-concept details, and any logs or screenshots that help us
-      validate the issue quickly.
+      proof-of-concept details, and any logs or screenshots that help validate
+      the issue quickly.
     </p>
 
     <p className="mt-8 font-bold">Scope</p>
     <p>
       This disclosure channel covers public Micrantha-owned websites,
       applications, and services. If you are unsure whether a system is in
-      scope, include the hostname or repository reference in your report and we
-      will clarify.
+      scope, include the hostname or repository reference in your report so
+      Micrantha can clarify.
     </p>
 
     <p className="mt-8 font-bold">Good-Faith Research</p>
     <p>
-      We welcome reports from researchers acting in good faith to help us
-      improve the security of our systems.
+      Good-faith security research is welcome when it helps improve the security
+      of Micrantha systems.
     </p>
     <p>Please avoid:</p>
     <ul>
@@ -53,9 +53,9 @@ const Security = () => (
 
     <p className="mt-8 font-bold">What to Expect</p>
     <p>
-      We will review reports, validate issues, and prioritize remediation based
-      on severity and impact. If you want coordinated disclosure, note that in
-      your report and include your preferred contact details.
+      Reports are reviewed, validated, and prioritized for remediation based on
+      severity and impact. For coordinated disclosure, note that in the report
+      and include your preferred contact details.
     </p>
 
     <p className="mt-8 font-bold">Bug Bounty</p>

--- a/app/routes/services.tsx
+++ b/app/routes/services.tsx
@@ -21,7 +21,7 @@ export const Services = () => (
       <h2 className="text-xl">Request a consultation</h2>
       <p>
         Request a consultation if you need to turn a fragile product, platform,
-        or workflow into a production system. Reach us at{" "}
+        or workflow into a production system. Contact{" "}
         <a href="mailto:services@micrantha.com?subject=Consultation">
           services@micrantha.com
         </a>

--- a/e2e/routes.spec.ts
+++ b/e2e/routes.spec.ts
@@ -110,7 +110,7 @@ test("/privacy retains the tailored long-form policy copy", async ({
   ).toBeVisible()
   await expect(page.getByText("Information Collection and Use")).toBeVisible()
   await expect(page.getByText("Cookies", { exact: true })).toBeVisible()
-  await expect(page.getByText("Contact Us", { exact: true })).toBeVisible()
+  await expect(page.getByText("Contact", { exact: true })).toBeVisible()
   await expect(page.getByText("fortunes.micrantha.com")).toHaveCount(0)
 })
 

--- a/tests/unit/site-voice.test.js
+++ b/tests/unit/site-voice.test.js
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import test from "node:test"
+
+const siteCopyFiles = [
+  "app/routes/_index.tsx",
+  "app/routes/philosophy.tsx",
+  "app/routes/privacy.tsx",
+  "app/routes/security.tsx",
+  "app/routes/services.tsx",
+  "app/routes/support.tsx",
+]
+
+const firstPersonPlural = /\b(?:we|our|ours|ourselves|us)\b/gi
+
+for (const file of siteCopyFiles) {
+  test(`${file} uses project-centered site voice`, () => {
+    const source = readFileSync(file, "utf8")
+    const matches = [...source.matchAll(firstPersonPlural)].map(
+      ({ 0: word, index = 0 }) => {
+        const line = source.slice(0, index).split("\n").length
+        return `${word} (line ${line})`
+      },
+    )
+
+    assert.deepEqual(
+      matches,
+      [],
+      `${file} contains first-person plural site copy: ${matches.join(", ")}`,
+    )
+  })
+}


### PR DESCRIPTION
## What changed

- removes organizational first-person plural copy (`we`, `our`, `us`) from the homepage, services, philosophy, privacy, and security routes
- replaces it with project-centered or direct language using `Micrantha`, neutral statements, or user-centered phrasing
- renames homepage labels such as `What We Bring` and `How We Work`
- keeps privacy and security accountability explicit rather than hiding the actor behind passive voice
- adds a unit regression test covering the primary site-copy routes
- updates the privacy Playwright assertion for the new `Contact` heading

## Why

Micrantha should read as a project/platform rather than a corporate team voice. Project-centered wording is more precise and better matches the site’s intended identity.

## Validation

- branch synchronized with current `main`
- diff reviewed for the affected routes
- unit regression coverage added for first-person plural site copy
- formatting and lint pass
- typecheck and production build pass
- performance budgets and Cloudflare integration pass
- functional Playwright and Cloudflare hydration browser contracts pass

CI run #321 is green.